### PR TITLE
fix: bump stdlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        deno_version: [ 'v1.0.0', 'v1.1.0', 'v1.1.2' ]
+        deno_version: [ 'v1.2.0' ]
 
     steps:
       - name: Configure git

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/ansi-escape/README.md
+++ b/packages/ansi-escape/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github&color=blue" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/ansi-escape/lib/ansi-escape.ts
+++ b/packages/ansi-escape/lib/ansi-escape.ts
@@ -1,4 +1,4 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
 import { cursor, erase, image, ImageOptions, link, scroll } from './csi.ts';
 
 export class AnsiEscape {

--- a/packages/command/README.md
+++ b/packages/command/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github&color=blue" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/command/commands/completions.ts
+++ b/packages/command/commands/completions.ts
@@ -1,4 +1,4 @@
-import { bold, dim, italic } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, dim, italic } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Command } from '../lib/command.ts';
 import { BashCompletionsCommand } from './completions/bash.ts';
 import { CompleteCommand } from './completions/complete.ts';

--- a/packages/command/commands/completions/complete.ts
+++ b/packages/command/commands/completions/complete.ts
@@ -1,4 +1,4 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
 import { IFlags } from '../../../flags/lib/types.ts';
 import { Command } from '../../lib/command.ts';
 import { ICompleteSettings } from '../../lib/types.ts';

--- a/packages/command/lib/arguments-parser.ts
+++ b/packages/command/lib/arguments-parser.ts
@@ -1,4 +1,4 @@
-import { green, magenta, red, yellow } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { green, magenta, red, yellow } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { OptionType } from '../../flags/lib/types.ts';
 import { IArgumentDetails } from './types.ts';
 

--- a/packages/command/lib/command.ts
+++ b/packages/command/lib/command.ts
@@ -1,6 +1,6 @@
 const { stdout, stderr } = Deno;
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
-import { dim, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
+import { dim, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { parseFlags } from '../../flags/lib/flags.ts';
 import { IFlagArgument, IFlagOptions, IFlagsResult, IFlagValue, IFlagValueHandler, IFlagValueType, ITypeHandler } from '../../flags/lib/types.ts';
 import { fill } from '../../flags/lib/utils.ts';

--- a/packages/command/lib/help-generator.ts
+++ b/packages/command/lib/help-generator.ts
@@ -1,4 +1,4 @@
-import { blue, bold, dim, magenta, red, yellow } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue, bold, dim, magenta, red, yellow } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { IFlagOptions } from '../../flags/lib/types.ts';
 import { Table } from '../../table/lib/table.ts';
 import format from '../../x/format.ts';

--- a/packages/command/test/lib/assert.ts
+++ b/packages/command/test/lib/assert.ts
@@ -1,7 +1,7 @@
 export {
     assert,
     assertEquals,
-    assertStrictEq,
+    assertStrictEquals,
     assertThrows,
     assertThrowsAsync
-} from 'https://deno.land/std@v0.52.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.61.0/testing/asserts.ts';

--- a/packages/flags/README.md
+++ b/packages/flags/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github&color=blue" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/flags/test/lib/assert.ts
+++ b/packages/flags/test/lib/assert.ts
@@ -1,7 +1,7 @@
 export {
     assert,
     assertEquals,
-    assertStrictEq,
+    assertStrictEquals,
     assertThrows,
     assertThrowsAsync
-} from 'https://deno.land/std@v0.52.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.61.0/testing/asserts.ts';

--- a/packages/keycode/README.md
+++ b/packages/keycode/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github&color=blue" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/keycode/lib/key-code.ts
+++ b/packages/keycode/lib/key-code.ts
@@ -1,4 +1,4 @@
-import { decode, encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
+import { decode, encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
 import { KeyMap, KeyMapCtrl, KeyMapShift } from './key-codes.ts';
 import { IKey, KeyEvent } from './key-event.ts';
 

--- a/packages/keycode/test/lib/assert.ts
+++ b/packages/keycode/test/lib/assert.ts
@@ -1,7 +1,7 @@
 export {
     assert,
     assertEquals,
-    assertStrictEq,
+    assertStrictEquals,
     assertThrows,
     assertThrowsAsync
-} from 'https://deno.land/std@v0.52.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.61.0/testing/asserts.ts';

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github&color=blue" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/prompt/lib/generic-input.ts
+++ b/packages/prompt/lib/generic-input.ts
@@ -1,5 +1,5 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
-import { underline } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
+import { underline } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { KeyEvent } from '../../keycode/lib/key-event.ts';
 import { stripeColors } from '../../table/lib/utils.ts';
 import { GenericPrompt, GenericPromptOptions, GenericPromptSettings } from './generic-prompt.ts';

--- a/packages/prompt/lib/generic-prompt.ts
+++ b/packages/prompt/lib/generic-prompt.ts
@@ -1,5 +1,5 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
-import { blue, bold, dim, green, red, yellow } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
+import { blue, bold, dim, green, red, yellow } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { AnsiEscape } from '../../ansi-escape/lib/ansi-escape.ts';
 import { KeyEvent } from '../../keycode/lib/key-event.ts';
 import format from '../../x/format.ts';

--- a/packages/prompt/lib/read-line.ts
+++ b/packages/prompt/lib/read-line.ts
@@ -1,5 +1,5 @@
-import { decode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
-import { BufReader } from 'https://deno.land/std@v0.52.0/io/bufio.ts';
+import { decode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
+import { BufReader } from 'https://deno.land/std@v0.61.0/io/bufio.ts';
 import { KeyCode, KeyEvent } from '../../keycode/mod.ts';
 
 export async function readLineSync(): Promise<string | undefined> {

--- a/packages/prompt/prompts/checkbox.ts
+++ b/packages/prompt/prompts/checkbox.ts
@@ -1,4 +1,4 @@
-import { blue, dim, green, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue, dim, green, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { KeyEvent } from '../../keycode/mod.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericList, GenericListOption, GenericListOptions, GenericListOptionSettings, GenericListSettings } from '../lib/generic-list.ts';

--- a/packages/prompt/prompts/confirm.ts
+++ b/packages/prompt/prompts/confirm.ts
@@ -1,4 +1,4 @@
-import { blue, bold, dim, yellow } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue, bold, dim, yellow } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericInput, GenericInputPromptOptions, GenericInputPromptSettings } from '../lib/generic-input.ts';
 

--- a/packages/prompt/prompts/input.ts
+++ b/packages/prompt/prompts/input.ts
@@ -1,4 +1,4 @@
-import { blue } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericInput, GenericInputPromptOptions, GenericInputPromptSettings } from '../lib/generic-input.ts';
 

--- a/packages/prompt/prompts/list.ts
+++ b/packages/prompt/prompts/list.ts
@@ -1,5 +1,5 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
-import { blue, underline } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
+import { blue, underline } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { stripeColors } from '../../table/lib/utils.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericInput, GenericInputPromptOptions, GenericInputPromptSettings } from '../lib/generic-input.ts';

--- a/packages/prompt/prompts/number.ts
+++ b/packages/prompt/prompts/number.ts
@@ -1,4 +1,4 @@
-import { blue } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { KeyEvent } from '../../keycode/lib/key-event.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericInput, GenericInputPromptOptions, GenericInputPromptSettings } from '../lib/generic-input.ts';

--- a/packages/prompt/prompts/secret.ts
+++ b/packages/prompt/prompts/secret.ts
@@ -1,5 +1,5 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
-import { blue, green, underline } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
+import { blue, green, underline } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { stripeColors } from '../../table/lib/utils.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericInput, GenericInputPromptOptions, GenericInputPromptSettings } from '../lib/generic-input.ts';

--- a/packages/prompt/prompts/select.ts
+++ b/packages/prompt/prompts/select.ts
@@ -1,4 +1,4 @@
-import { blue, dim } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue, dim } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { KeyEvent } from '../../keycode/lib/key-event.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericList, GenericListOption, GenericListOptions, GenericListOptionSettings, GenericListSettings } from '../lib/generic-list.ts';

--- a/packages/prompt/prompts/toggle.ts
+++ b/packages/prompt/prompts/toggle.ts
@@ -1,4 +1,4 @@
-import { blue, dim, underline } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { blue, dim, underline } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { KeyEvent } from '../../keycode/lib/key-event.ts';
 import { Figures } from '../lib/figures.ts';
 import { GenericInput, GenericInputPromptOptions, GenericInputPromptSettings } from '../lib/generic-input.ts';

--- a/packages/prompt/test/checkbox_test.ts
+++ b/packages/prompt/test/checkbox_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Checkbox } from '../prompts/checkbox.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/confirm_test.ts
+++ b/packages/prompt/test/confirm_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Confirm } from '../prompts/confirm.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/input_test.ts
+++ b/packages/prompt/test/input_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Input } from '../prompts/input.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/lib/assert.ts
+++ b/packages/prompt/test/lib/assert.ts
@@ -1,7 +1,7 @@
 export {
     assert,
     assertEquals,
-    assertStrictEq,
+    assertStrictEquals,
     assertThrows,
     assertThrowsAsync
-} from 'https://deno.land/std@v0.52.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.61.0/testing/asserts.ts';

--- a/packages/prompt/test/list_test.ts
+++ b/packages/prompt/test/list_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { List } from '../prompts/list.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/number_test.ts
+++ b/packages/prompt/test/number_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Number } from '../prompts/number.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/secret_test.ts
+++ b/packages/prompt/test/secret_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Secret } from '../prompts/secret.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/select_test.ts
+++ b/packages/prompt/test/select_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Select } from '../prompts/select.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/prompt/test/toggle_test.ts
+++ b/packages/prompt/test/toggle_test.ts
@@ -1,4 +1,4 @@
-import { bold, red } from 'https://deno.land/std@v0.52.0/fmt/colors.ts';
+import { bold, red } from 'https://deno.land/std@v0.61.0/fmt/colors.ts';
 import { Toggle } from '../prompts/toggle.ts';
 import { assertEquals, assertThrowsAsync } from './lib/assert.ts';
 

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -8,7 +8,7 @@
     <img alt="Release date" src="https://img.shields.io/github/release-date/c4spar/deno-cliffy?logo=github&color=blue" />
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.0.0-blue?logo=deno" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.2.0-blue?logo=deno" />
   </a>
   <a href="https://github.com/c4spar/deno-cliffy/actions?query=workflow%3Aci">
     <img alt="Build status" src="https://github.com/c4spar/deno-cliffy/workflows/ci/badge.svg?branch=master" />

--- a/packages/table/lib/table.ts
+++ b/packages/table/lib/table.ts
@@ -1,4 +1,4 @@
-import { encode } from 'https://deno.land/std@v0.52.0/encoding/utf8.ts';
+import { encode } from 'https://deno.land/std@v0.61.0/encoding/utf8.ts';
 import { border } from './border.ts';
 import { Cell, ICell } from './cell.ts';
 import { CELL_PADDING, MAX_CELL_WIDTH, MIN_CELL_WIDTH } from './const.ts';

--- a/packages/table/test/lib/assert.ts
+++ b/packages/table/test/lib/assert.ts
@@ -1,7 +1,7 @@
 export {
     assert,
     assertEquals,
-    assertStrictEq,
+    assertStrictEquals,
     assertThrows,
     assertThrowsAsync
-} from 'https://deno.land/std@v0.52.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.61.0/testing/asserts.ts';


### PR DESCRIPTION
stdlib 0.61.0 introduced breaking changes.  Changes:

- bumped all stdlib references to 0.61.0
- changes `assertStrictEq` to `assertStrictEquals`