### PR TITLE
feat(flags,command): improve support for negatable options

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -279,39 +279,35 @@ Missing required option: --cheese
 
 ### Negatable options
 
-You can call the long name from an option with a boolean or an optional value (declared using square brackets) with a leading `--no-` to set the option value to false when used.
+You can specify a boolean option long name with a leading `no-` to set the option value to false when used.
+Defined alone this also makes the option true by default.
 
-You can specify a default value for the flag and it can be overridden on command line.
+If you define `--foo`, adding `--no-foo` does not change the default value from what it would otherwise be.
+
+You can specify a default value for a flag and it can be overridden on command line.
 
 ```typescript
 import { Command } from "https://deno.land/x/cliffy/command/mod.ts";
 
 const { options } = await new Command()
-  .option("--sauce [sauce:boolean]", "Remove sauce", {
-    default: true,
-  })
-  .option("--cheese [flavour:string]", "cheese flavour", {
-    default: "mozzarella",
-  })
+  // default value will be automatically set to true if no --check option exists
+  .option("--no-check", "No check.")
+  .option("--color <color:string>", "Color name.", { default: "yellow" })
+  .option("--no-color", "No color.")
+  // no default value
+  .option("--remote <url:string>", "Remote url.")
+  .option("--no-remote", "No remote.")
   .parse(Deno.args);
 
-const sauceStr = options.sauce ? "sauce" : "no sauce";
-const cheeseStr = options.cheese === false
-  ? "no cheese"
-  : `${options.cheese} cheese`;
-
-console.log(`You ordered a pizza with ${sauceStr} and ${cheeseStr}`);
+console.log(options);
 ```
 
 ```
 $ deno run https://deno.land/x/cliffy/examples/command/negatable_options.ts
-You ordered a pizza with sauce and mozzarella cheese
+{ check: true, color: "yellow" }
 
-$ deno run https://deno.land/x/cliffy/examples/command/negatable_options.ts --no-sauce --no-cheese
-You ordered a pizza with no sauce and no cheese
-
-$ deno run https://deno.land/x/cliffy/examples/command/negatable_options.ts --sauce --cheese parmesan
-You ordered a pizza with sauce and parmesan cheese
+$ deno run https://deno.land/x/cliffy/examples/command/negatable_options.ts --no-check --no-color --no-remote
+{ check: false, color: false, remote: false }
 ```
 
 ### Global options

--- a/command/test/option/duplicate_test.ts
+++ b/command/test/option/duplicate_test.ts
@@ -4,6 +4,7 @@ import { Command } from "../../command.ts";
 const cmd = new Command()
   .throwErrors()
   .option("-f, --flag [value:boolean]", "description ...")
+  .option("--no-flag", "description ...")
   .action(() => {});
 
 Deno.test("command optionDuplicate flag", async () => {

--- a/command/test/option/negatable_test.ts
+++ b/command/test/option/negatable_test.ts
@@ -1,0 +1,74 @@
+import { assertEquals, assertThrowsAsync } from "../../../dev_deps.ts";
+import { Command } from "../../command.ts";
+
+function command(): Command {
+  return new Command()
+    .throwErrors()
+    .allowEmpty()
+    .option("--no-check", "No check.")
+    .option("--color <color:string>", "Color name.", { default: "yellow" })
+    .option("--no-color", "No color.")
+    .option("--remote <url:string>", "Remote url.", { depends: ["color"] })
+    .option("--no-remote", "No remote.");
+}
+
+Deno.test("negatable options with no arguments", async () => {
+  const { options, args, literal } = await command().parse([]);
+
+  assertEquals(options, {
+    check: true,
+    color: "yellow",
+  });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("negatable options with arguments", async () => {
+  const { options, args, literal } = await command().parse(
+    ["--color", "blue", "--remote", "foo"],
+  );
+
+  assertEquals(options, {
+    check: true,
+    color: "blue",
+    remote: "foo",
+  });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("negatable flag --no-remote should not depend on --color", async () => {
+  const { options, args, literal } = await command().parse(["--no-remote"]);
+
+  assertEquals(options, {
+    check: true,
+    color: "yellow",
+    remote: false,
+  });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("negatable flags should negate value", async () => {
+  const { options, args, literal } = await command().parse(
+    ["--no-check", "--no-color", "--no-remote"],
+  );
+
+  assertEquals(options, {
+    color: false,
+    check: false,
+    remote: false,
+  });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("negatable options should not be combinable with positive options", async () => {
+  await assertThrowsAsync(
+    async () => {
+      await command().parse(["--color", "--no-color", "--no-check"]);
+    },
+    Error,
+    "Duplicate option: --no-color",
+  );
+});

--- a/command/test/type/boolean_test.ts
+++ b/command/test/type/boolean_test.ts
@@ -5,6 +5,7 @@ const cmd = new Command()
   .throwErrors()
   .name("test-command")
   .option("-f, --flag [value:boolean]", "description ...")
+  .option("--no-flag", "description ...")
   .action(() => {});
 
 Deno.test("command typeString flag", async () => {

--- a/command/test/type/number_test.ts
+++ b/command/test/type/number_test.ts
@@ -3,7 +3,9 @@ import { Command } from "../../command.ts";
 
 const cmd = new Command()
   .throwErrors()
-  .option("-f, --flag [value:number]", "description ...").action(() => {});
+  .option("-f, --flag [value:number]", "description ...")
+  .option("--no-flag", "description ...")
+  .action(() => {});
 
 Deno.test("command typeString flag", async () => {
   const { options, args } = await cmd.parse(["-f"]);

--- a/command/test/type/string_test.ts
+++ b/command/test/type/string_test.ts
@@ -3,7 +3,9 @@ import { Command } from "../../command.ts";
 
 const cmd = new Command()
   .throwErrors()
-  .option("-f, --flag [value:string]", "description ...").action(() => {});
+  .option("-f, --flag [value:string]", "description ...")
+  .option("--no-flag", "description ...")
+  .action(() => {});
 
 Deno.test("command typeString flag", async () => {
   const { options, args } = await cmd.parse(["-f"]);

--- a/examples/command/negatable_options.ts
+++ b/examples/command/negatable_options.ts
@@ -3,17 +3,13 @@
 import { Command } from "../../command/command.ts";
 
 const { options } = await new Command()
-  .option("--sauce [sauce:boolean]", "Remove sauce", {
-    default: true,
-  })
-  .option("--cheese [flavour:string]", "cheese flavour", {
-    default: "mozzarella",
-  })
+  // default value will be automatically set to true if no --check option exists
+  .option("--no-check", "No check.")
+  .option("--color <color:string>", "Color name.", { default: "yellow" })
+  .option("--no-color", "No color.")
+  // no default value
+  .option("--remote <url:string>", "Remote url.")
+  .option("--no-remote", "No remote.")
   .parse(Deno.args);
 
-const sauceStr = options.sauce ? "sauce" : "no sauce";
-const cheeseStr = options.cheese === false
-  ? "no cheese"
-  : `${options.cheese} cheese`;
-
-console.log(`You ordered a pizza with ${sauceStr} and ${cheeseStr}`);
+console.log(options);

--- a/flags/test/option/collect_test.ts
+++ b/flags/test/option/collect_test.ts
@@ -11,6 +11,8 @@ const options = <IParseOptions> {
     type: OptionType.STRING,
     optionalValue: true,
   }, {
+    name: "no-flag",
+  }, {
     name: "string",
     aliases: ["s"],
     type: OptionType.STRING,
@@ -56,14 +58,6 @@ Deno.test("flags optionCollect flagTrueLongFalse", () => {
 Deno.test("flags optionCollect flagTrueNoFlag", () => {
   assertThrows(
     () => parseFlags(["-f", "true", "--no-flag"], options),
-    Error,
-    "Duplicate option: --no-flag",
-  );
-});
-
-Deno.test("flags optionCollect flagTrueNoFlagTrue", () => {
-  assertThrows(
-    () => parseFlags(["-f", "true", "--no-flag", "true"], options),
     Error,
     "Duplicate option: --no-flag",
   );

--- a/flags/test/option/depends_test.ts
+++ b/flags/test/option/depends_test.ts
@@ -111,6 +111,10 @@ const options2 = {
     optionalValue: true,
     depends: ["flag1"],
     default: false,
+  }, {
+    name: "no-flag1",
+  }, {
+    name: "no-flag2",
   }],
 };
 
@@ -130,9 +134,9 @@ Deno.test("flags depends: should accept --standalone", () => {
   assertEquals(literal, []);
 });
 
-Deno.test("flags depends: should not accept --no-flag2", () => {
+Deno.test("flags depends: should not accept --flag2", () => {
   assertThrows(
-    () => parseFlags(["--no-flag2"], options2),
+    () => parseFlags(["--flag2"], options2),
     Error,
     "Option --flag2 depends on option: --flag1",
   );

--- a/flags/test/option/negatable_test.ts
+++ b/flags/test/option/negatable_test.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assertThrows } from "../../../dev_deps.ts";
+import { parseFlags } from "../../flags.ts";
+import type { IParseOptions } from "../../types.ts";
+
+const options = <IParseOptions> {
+  allowEmpty: true,
+  flags: [{
+    name: "remote",
+  }, {
+    name: "color",
+  }, {
+    name: "no-color",
+  }, {
+    name: "no-check",
+  }],
+};
+
+Deno.test("negatable flags with no arguments", () => {
+  const { flags, unknown, literal } = parseFlags([], options);
+
+  assertEquals(flags, {
+    check: true,
+  });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("negatable flags", () => {
+  const { flags, unknown, literal } = parseFlags(
+    ["--no-color", "--no-check"],
+    options,
+  );
+
+  assertEquals(flags, {
+    color: false,
+    check: false,
+  });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("duplicate option with negatable flags", () => {
+  assertThrows(
+    () => parseFlags(["--color", "--no-color", "--no-check"], options),
+    Error,
+    "Duplicate option: --no-color",
+  );
+});
+
+Deno.test("unknown negatable flag", () => {
+  assertThrows(
+    () => parseFlags(["--no-remote"], options),
+    Error,
+    "Unknown option: --no-remote",
+  );
+});

--- a/flags/test/type/boolean_test.ts
+++ b/flags/test/type/boolean_test.ts
@@ -11,6 +11,8 @@ const options = {
     type: OptionType.BOOLEAN,
     optionalValue: true,
     standalone: true,
+  }, {
+    name: "no-flag",
   }],
 };
 


### PR DESCRIPTION
This PR improves the support of negatable options.

Before:
* all options with a boolean flag or an optional value were able to be called with a leading `no-` to set the option value to false.
* It was't possible to define options with a leading `no-` because of a bug.

With this PR:
* It's required to define negatable options manually.
* Add support for adding descriptions for negatable options.

Example:
```typescript
const { options } = await new Command()
  // default value will be automatically set to true if no --check option exists.
  // set's check to false if called.
  .option("--no-check", "No check.")
  .option("--color <color>", "Color name.", { default: "yellow" })
  // set's color to false if called.
  .option("--no-color", "No color.")
  // no default value
  .option("--remote <url>", "Remote url.")
  // set's remote to false if called.
  .option("--no-remote", "No remote.")
  .parse(Deno.args);

console.log(options);
```

```
$ deno run example.ts
{ check: true, color: "yellow" }

$ deno run example.ts --no-check --no-color --no-remote
{ check: false, color: false, remote: false }
```

closes: #102 