### PR TITLE
feat(flags,command): add support for dotted options

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -34,6 +34,7 @@
   - [Common option types: string, number and boolean](#common-option-types-string-number-and-boolean)
   - [List option types](#list-option-types)
   - [Variadic options](#variadic-options)
+  - [Dotted options](#dotted-options)
   - [Default option value](#default-option-value)
   - [Required options](#required-options)
   - [Negatable options](#negatable-options)
@@ -231,6 +232,39 @@ The variadic option is returned as an array.
 ```
 $ deno run https://deno.land/x/cliffy/examples/command/variadic_options.ts -d dir1 dir2 dir3
 { dir: [ "dir1", "dir2", "dir3" ] }
+```
+
+### Dotted options
+
+Dotted options allows you to group your options together in nested objects.
+There is no limit for the level of nested objects.
+
+```typescript
+import { Command } from "https://deno.land/x/cliffy/command/mod.ts";
+
+const { options } = await new Command()
+  .option(
+    "-b.a, --bitrate.audio, --audio-bitrate <bitrate:number>",
+    "Audio bitrate",
+  )
+  .option(
+    "-b.v, --bitrate.video, --video-bitrate <bitrate:number>",
+    "Video bitrate",
+  )
+  .parse();
+
+console.log(options);
+```
+
+```
+$ deno run https://deno.land/x/cliffy/examples/command/dotted_options.ts -b.a 300 -b.v 900
+{ bitrate: { audio: 300, video: 900 } }
+
+$ deno run https://deno.land/x/cliffy/examples/command/dotted_options.ts --bitrate.audio 300 --bitrate.video 900
+{ bitrate: { audio: 300, video: 900 } }
+
+$ deno run https://deno.land/x/cliffy/examples/command/dotted_options.ts --audio-bitrate 300 --video-bitrate 900
+{ bitrate: { audio: 300, video: 900 } }
 ```
 
 ### Default option value

--- a/command/test/command/dotted_options_test.ts
+++ b/command/test/command/dotted_options_test.ts
@@ -1,0 +1,68 @@
+import { assertEquals, assertThrowsAsync } from "../../../dev_deps.ts";
+import { Command } from "../../command.ts";
+
+function cmd(): Command {
+  return new Command()
+    .throwErrors()
+    .option(
+      "-b.a, --bitrate.audio, --audio-bitrate <bitrate:number>",
+      "Audio bitrate",
+      {
+        depends: ["bitrate.video"],
+      },
+    )
+    .option(
+      "-b.v, --bitrate.video, --video-bitrate <bitrate:number>",
+      "Video bitrate",
+      {
+        depends: ["bitrate.audio"],
+      },
+    )
+    .action(() => {});
+}
+
+Deno.test("command: dotted short options", async () => {
+  const { options, args, literal } = await cmd().parse(
+    ["-b.a", "300", "-b.v", "900"],
+  );
+
+  assertEquals(options, { bitrate: { audio: 300, video: 900 } });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("command: dotted long options", async () => {
+  const { options, args, literal } = await cmd().parse(
+    ["--bitrate.audio", "300", "--bitrate.video", "900"],
+  );
+
+  assertEquals(options, { bitrate: { audio: 300, video: 900 } });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("command: dotted aliases", async () => {
+  const { options, args, literal } = await cmd().parse(
+    ["--audio-bitrate", "300", "--video-bitrate", "900"],
+  );
+
+  assertEquals(options, { bitrate: { audio: 300, video: 900 } });
+  assertEquals(args, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("command: dotted aliases", () => {
+  assertThrowsAsync(
+    () => cmd().parse(["--audio-bitrate", "300"]),
+    Error,
+    "Option --bitrate.audio depends on option: --bitrate.video",
+  );
+});
+
+Deno.test("command: dotted option with invalid value", () => {
+  assertThrowsAsync(
+    () => cmd().parse(["--bitrate.audio", "300", "--bitrate.video", "900k"]),
+    Error,
+    "Option --bitrate.video must be of type number but got: 900k",
+  );
+});

--- a/examples/command/dotted_options.ts
+++ b/examples/command/dotted_options.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S deno run
+
+import { Command } from "../../command/command.ts";
+
+const { options } = await new Command()
+  .option(
+    "-b.a, --bitrate.audio, --audio-bitrate <bitrate:number>",
+    "Audio bitrate",
+  )
+  .option(
+    "-b.v, --bitrate.video, --video-bitrate <bitrate:number>",
+    "Video bitrate",
+  )
+  .parse();
+
+console.log(options);

--- a/examples/flags/dotted_options.ts
+++ b/examples/flags/dotted_options.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env -S deno run
+
+import { parseFlags } from "../../flags/flags.ts";
+import { OptionType } from "../../flags/types.ts";
+
+const result = parseFlags(Deno.args, {
+  allowEmpty: true,
+  stopEarly: true,
+  flags: [{
+    name: "bitrate.audio",
+    aliases: ["b.a", "audio-bitrate"],
+    type: OptionType.NUMBER,
+  }, {
+    name: "bitrate.video",
+    aliases: ["b.v", "video-bitrate"],
+    type: OptionType.NUMBER,
+  }],
+});
+
+console.log(result);

--- a/flags/README.md
+++ b/flags/README.md
@@ -71,11 +71,20 @@ $ deno run https://deno.land/x/cliffy/examples/flags/flags.ts -a foo -b bar
 ```
 
 ```
-$ deno run https://deno.land/x/cliffy/examples/flags/flags.ts -x 3 -y 4 -n5 -abc --beep=boop foo bar baz
+$ deno run https://deno.land/x/cliffy/examples/flags/flags.ts -x 3 -y.z -n5 -abc --beep=boop foo bar baz --deno.land -- --cliffy
 {
-  flags: { x: "3", y: "4", n: "5", a: true, b: true, c: true, beep: "boop" },
+  flags: {
+    x: "3",
+    y: { z: true },
+    n: "5",
+    a: true,
+    b: true,
+    c: true,
+    beep: "boop",
+    deno: { land: true }
+  },
   unknown: [ "foo", "bar", "baz" ],
-  literal: []
+  literal: [ "--cliffy" ]
 }
 ```
 

--- a/flags/normalize.ts
+++ b/flags/normalize.ts
@@ -15,6 +15,7 @@ export function normalize(args: string[]) {
       normalized.push(arg);
     } else if (arg.length > 1 && arg[0] === "-") {
       const isLong = arg[1] === "-";
+      const isDotted = !isLong && arg[2] === ".";
 
       if (arg.includes("=")) {
         const parts = arg.split("=");
@@ -26,7 +27,7 @@ export function normalize(args: string[]) {
           normalizeShortFlags(flag);
         }
         normalized.push(parts.join("="));
-      } else if (isLong) {
+      } else if (isLong || isDotted) {
         normalized.push(arg);
       } else {
         normalizeShortFlags(arg);

--- a/flags/test/flags/dotted_options_test.ts
+++ b/flags/test/flags/dotted_options_test.ts
@@ -1,0 +1,71 @@
+import { assertEquals, assertThrows } from "../../../dev_deps.ts";
+import { parseFlags } from "../../flags.ts";
+import type { IParseOptions } from "../../types.ts";
+import { OptionType } from "../../types.ts";
+
+const options = <IParseOptions> {
+  flags: [{
+    name: "bitrate.audio",
+    aliases: ["b.a", "audio-bitrate"],
+    type: OptionType.NUMBER,
+    depends: ["bitrate.video"],
+  }, {
+    name: "bitrate.video",
+    aliases: ["b.v", "video-bitrate"],
+    type: OptionType.NUMBER,
+    depends: ["bitrate.audio"],
+  }],
+};
+
+Deno.test("flags: dotted short options", () => {
+  const { flags, unknown, literal } = parseFlags(
+    ["-b.a", "300", "-b.v", "900"],
+    options,
+  );
+
+  assertEquals(flags, { bitrate: { audio: 300, video: 900 } });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("flags: dotted long options", () => {
+  const { flags, unknown, literal } = parseFlags(
+    ["--bitrate.audio", "300", "--bitrate.video", "900"],
+    options,
+  );
+
+  assertEquals(flags, { bitrate: { audio: 300, video: 900 } });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("flags: dotted aliases", () => {
+  const { flags, unknown, literal } = parseFlags(
+    ["--audio-bitrate", "300", "--video-bitrate", "900"],
+    options,
+  );
+
+  assertEquals(flags, { bitrate: { audio: 300, video: 900 } });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("flags: dotted aliases", () => {
+  assertThrows(
+    () => parseFlags(["--audio-bitrate", "300"], options),
+    Error,
+    "Option --bitrate.audio depends on option: --bitrate.video",
+  );
+});
+
+Deno.test("flags: dotted option with invalid value", () => {
+  assertThrows(
+    () =>
+      parseFlags(
+        ["--bitrate.audio", "300", "--bitrate.video", "900k"],
+        options,
+      ),
+    Error,
+    "Option --bitrate.video must be of type number but got: 900k",
+  );
+});


### PR DESCRIPTION
This PR add's support for dotted options.

**Example:**
```typescript
import { Command } from "https://deno.land/x/cliffy/command/mod.ts";

const { options } = await new Command()
  .option(
    "-b.a, --bitrate.audio, --audio-bitrate <bitrate:number>",
    "Audio bitrate",
  )
  .option(
    "-b.v, --bitrate.video, --video-bitrate <bitrate:number>",
    "Video bitrate",
  )
  .parse();

console.log(options);
```

**Output:**
```
$ deno run example.ts -b.a 300 -b.v 900
{ bitrate: { audio: 300, video: 900 } }

$ deno run example.ts --bitrate.audio 300 --bitrate.video 900
{ bitrate: { audio: 300, video: 900 } }

$ deno run example.ts --audio-bitrate 300 --video-bitrate 900
{ bitrate: { audio: 300, video: 900 } }
```