### PR TITLE
fix(command): remove v prefix from version in generated help text

### DIFF
--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -72,7 +72,7 @@ export class HelpGenerator {
     ];
     const version: string | undefined = this.cmd.getVersion();
     if (version) {
-      rows.push([bold("Version:"), yellow(`v${this.cmd.getVersion()}`)]);
+      rows.push([bold("Version:"), yellow(`${this.cmd.getVersion()}`)]);
     }
     return "\n" +
       Table.from(rows)

--- a/command/test/command/help_command_test.ts
+++ b/command/test/command/help_command_test.ts
@@ -75,7 +75,7 @@ Deno.test({
       output,
       `
   Usage:   COMMAND
-  Version: v1.0.0 
+  Version: 1.0.0  
 
   Description:
 
@@ -118,7 +118,7 @@ Deno.test({
       output,
       `
   Usage:   COMMAND
-  Version: v1.0.0 
+  Version: 1.0.0  
 
   Description:
 

--- a/command/test/command/hidden_command_test.ts
+++ b/command/test/command/hidden_command_test.ts
@@ -36,7 +36,7 @@ Deno.test("hidden command help", () => {
   assertEquals(
     `
   Usage:   COMMAND
-  Version: v1.0.0 
+  Version: 1.0.0  
 
   Description:
 

--- a/command/test/integration/fixtures/help_command.out
+++ b/command/test/integration/fixtures/help_command.out
@@ -1,6 +1,6 @@
 
   [1mUsage:[22m   [35mcompletions-test[39m
-  [1mVersion:[22m [33mv1.0.0[39m          
+  [1mVersion:[22m [33m1.0.0[39m           
 
   [1mDescription:[22m
 

--- a/command/test/integration/fixtures/help_command_with_argument.out
+++ b/command/test/integration/fixtures/help_command_with_argument.out
@@ -1,6 +1,6 @@
 
   [1mUsage:[22m   [35mcompletions-test foo[39m
-  [1mVersion:[22m [33mv1.0.0[39m              
+  [1mVersion:[22m [33m1.0.0[39m               
 
   [1mDescription:[22m
 

--- a/command/test/integration/fixtures/help_option_long.out
+++ b/command/test/integration/fixtures/help_option_long.out
@@ -1,6 +1,6 @@
 
   [1mUsage:[22m   [35mcompletions-test[39m
-  [1mVersion:[22m [33mv1.0.0[39m          
+  [1mVersion:[22m [33m1.0.0[39m           
 
   [1mDescription:[22m
 

--- a/command/test/integration/fixtures/help_option_short.out
+++ b/command/test/integration/fixtures/help_option_short.out
@@ -1,6 +1,6 @@
 
   [1mUsage:[22m   [35mcompletions-test[39m
-  [1mVersion:[22m [33mv1.0.0[39m          
+  [1mVersion:[22m [33m1.0.0[39m           
 
   [1mDescription:[22m
 

--- a/command/test/option/hidden_test.ts
+++ b/command/test/option/hidden_test.ts
@@ -29,7 +29,7 @@ Deno.test("hidden option help", () => {
   assertEquals(
     `
   Usage:   COMMAND
-  Version: v1.0.0 
+  Version: 1.0.0  
 
   Description:
 


### PR DESCRIPTION
closes: #230