### PR TITLE
docs(ansi): fix functional example command

### DIFF
--- a/ansi/README.md
+++ b/ansi/README.md
@@ -156,7 +156,7 @@ console.log(
 ```
 
 ```
-$ deno run https://deno.land/x/cliffy/examples/ansi/functional.ts
+$ deno run --allow-net https://deno.land/x/cliffy/examples/ansi/functional.ts
 ```
 
 ### Tty


### PR DESCRIPTION
👋  Was playing around with the examples and tried out the functional example from the README, which resulted in an error:

```
❯ deno run https://deno.land/x/cliffy/examples/ansi/functional.ts
error: Uncaught PermissionDenied: Requires net access to "deno.land", run again with the --allow-net flag
    at deno:core/core.js:86:46
    at unwrapOpResult (deno:core/core.js:106:13)
    at Object.opSync (deno:core/core.js:120:12)
    at opFetch (deno:extensions/fetch/26_fetch.js:43:17)
    at mainFetch (deno:extensions/fetch/26_fetch.js:170:61)
    at deno:extensions/fetch/26_fetch.js:395:7
    at new Promise (<anonymous>)
    at fetch (deno:extensions/fetch/26_fetch.js:357:15)
    at https://deno.land/x/cliffy@v0.19.2/examples/ansi/functional.ts:3:24
❯ deno --version
deno 1.11.4 (release, x86_64-apple-darwin)
v8 9.1.269.35
typescript 4.3.2

```

I've updated the example to include Deno's `--allow-net` flag, and now the example works as expected.