### PR TITLE
fix(examples): fix type of args

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -917,7 +917,7 @@ import { Command } from "https://deno.land/x/cliffy/command/mod.ts";
 await new Command()
   .stopEarly() // <-- enable stop early
   .option("-d, --debug-level <level:string>", "Debug level.")
-  .arguments("[script:string] [...args:number]")
+  .arguments("[script:string] [...args:string]")
   .action((options: any, script: string, args: string[]) => {
     console.log("options:", options);
     console.log("script:", script);

--- a/examples/command/stop_early.ts
+++ b/examples/command/stop_early.ts
@@ -5,7 +5,7 @@ import { Command } from "../../command/command.ts";
 await new Command()
   .stopEarly() // <-- enable stop early
   .option("-d, --debug-level <level:string>", "Debug level.")
-  .arguments("[script:string] [...args:number]")
+  .arguments("[script:string] [...args:string]")
   // deno-lint-ignore no-explicit-any
   .action((options: any, script: string, args: string[]) => {
     console.log("options:", options);


### PR DESCRIPTION
Fix type of args in `examples/command/stop_early.ts` and the document about this.

Close #239 