### PR TITLE
Feature: Add option to not exit after --help

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -122,6 +122,7 @@ export class Command<
   private argsDefinition?: string;
   private isExecutable = false;
   private throwOnError = false;
+  private exitOnHelp = true;
   private _allowEmpty = true;
   private _stopEarly = false;
   private defaultCommand?: string;
@@ -666,6 +667,21 @@ export class Command<
     return this;
   }
 
+  /**
+   * Should Cliffy Exit on options such as --help or --version.
+   *
+   * **Example:**
+   *
+   * ```
+   * cmd.dontExitOnHelp()
+   *   .parse();
+   * ```
+   */
+  public dontExitOnHelp(): this {
+    this.cmd.exitOnHelp = false;
+    return this;
+  }
+
   /** Check whether the command should throw errors or exit. */
   protected shouldThrowErrors(): boolean {
     return this.cmd.throwOnError || !!this.cmd._parent?.shouldThrowErrors();
@@ -953,7 +969,9 @@ export class Command<
           prepend: true,
           action: function () {
             this.showVersion();
-            Deno.exit(0);
+            if (this.exitOnHelp) {
+              Deno.exit(0);
+            }
           },
           ...(this._versionOption?.opts ?? {}),
         },
@@ -970,7 +988,9 @@ export class Command<
           prepend: true,
           action: function () {
             this.showHelp();
-            Deno.exit(0);
+            if (this.exitOnHelp) {
+              Deno.exit(0);
+            }
           },
           ...(this._helpOption?.opts ?? {}),
         },


### PR DESCRIPTION
Whilst making an interactive cli I found it usefull for user to be able to run --help on commands.

Without something like this the process will exit.

This change keeps all current default behaviour, but maybe it could be implemented better, (i mostly coppied the style of the throwErrors option.)

Example code:

```javascript
  const text = Input.prompt({message: "Server"});

  Cliffy.Command()
      .throwErrors()
      .dontExitOnHelp()
      ...
      .parse(command.split(" "));
```

example of it in use:

![ezgif-2-88245460975c](https://user-images.githubusercontent.com/44343744/130157044-3b853d8b-ec4e-4d83-9e21-429aad399c0a.gif)
