### PR TITLE
Feature: Add option to not exit after --help (round 2)

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -1249,6 +1249,8 @@ await new Command()
     hints: true, // default: true
     // Enable/disable colors.
     colors: false, // default: true
+    // Enable/disable exiting after print
+    exit: true, // default: true
   })
   .option("-f, --foo [val:number]", "Some description.", {
     required: true,

--- a/command/command.ts
+++ b/command/command.ts
@@ -679,7 +679,6 @@ export class Command<
 
   /** Check wether the command should exit after printing help */
   protected shouldExitOnHelp(): boolean {
-    // console.log(this.cmd._name, this.cmd.exitOnHelp, !!this.cmd._parent?.shouldExitOnHelp())
     return this.cmd.exitOnHelp ??
       (this.cmd._parent?.shouldExitOnHelp() ?? true);
   }

--- a/command/command.ts
+++ b/command/command.ts
@@ -680,7 +680,8 @@ export class Command<
   /** Check wether the command should exit after printing help */
   protected shouldExitOnHelp(): boolean {
     // console.log(this.cmd._name, this.cmd.exitOnHelp, !!this.cmd._parent?.shouldExitOnHelp())
-    return this.cmd.exitOnHelp ?? (this.cmd._parent?.shouldExitOnHelp() ?? true);
+    return this.cmd.exitOnHelp ??
+      (this.cmd._parent?.shouldExitOnHelp() ?? true);
   }
 
   public globalOption<G extends Record<string, unknown> | void = CG>(

--- a/command/command.ts
+++ b/command/command.ts
@@ -959,7 +959,7 @@ export class Command<
           prepend: true,
           action: function () {
             this.showVersion();
-            if(this.exitOnHelp){
+            if (this.exitOnHelp) {
               Deno.exit(0);
             }
           },
@@ -978,7 +978,7 @@ export class Command<
           prepend: true,
           action: function () {
             this.showHelp();
-            if(this.exitOnHelp){
+            if (this.exitOnHelp) {
               Deno.exit(0);
             }
           },

--- a/command/command.ts
+++ b/command/command.ts
@@ -137,7 +137,7 @@ export class Command<
   private _versionOption?: IDefaultOption | false;
   private _helpOption?: IDefaultOption | false;
   private _help?: IHelpHandler;
-  private exitOnHelp = true;
+  private exitOnHelp: undefined | boolean;
 
   /** Disable version option. */
   public versionOption(enable: false): this;
@@ -450,7 +450,7 @@ export class Command<
     } else if (typeof help === "function") {
       this.cmd._help = help;
     } else {
-      this.exitOnHelp = help.exit ?? true;
+      this.cmd.exitOnHelp = help.exit;
       this.cmd._help = (cmd: Command): string =>
         HelpGenerator.generate(cmd, help);
     }
@@ -675,6 +675,12 @@ export class Command<
   /** Check whether the command should throw errors or exit. */
   protected shouldThrowErrors(): boolean {
     return this.cmd.throwOnError || !!this.cmd._parent?.shouldThrowErrors();
+  }
+
+  /** Check wether the command should exit after printing help */
+  protected shouldExitOnHelp(): boolean {
+    // console.log(this.cmd._name, this.cmd.exitOnHelp, !!this.cmd._parent?.shouldExitOnHelp())
+    return this.cmd.exitOnHelp ?? (this.cmd._parent?.shouldExitOnHelp() ?? true);
   }
 
   public globalOption<G extends Record<string, unknown> | void = CG>(
@@ -959,7 +965,7 @@ export class Command<
           prepend: true,
           action: function () {
             this.showVersion();
-            if (this.exitOnHelp) {
+            if (this.shouldExitOnHelp()) {
               Deno.exit(0);
             }
           },
@@ -978,7 +984,7 @@ export class Command<
           prepend: true,
           action: function () {
             this.showHelp();
-            if (this.exitOnHelp) {
+            if (this.shouldExitOnHelp()) {
               Deno.exit(0);
             }
           },

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -34,7 +34,10 @@ export class HelpGenerator {
     return new HelpGenerator(cmd, options).generate();
   }
 
-  private constructor(private cmd: Command, options: HelpGeneratorOptions = {}) {
+  private constructor(
+    private cmd: Command,
+    options: HelpGeneratorOptions = {},
+  ) {
     this.options = {
       types: false,
       hints: true,

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -18,7 +18,7 @@ import type { IArgument } from "../types.ts";
 import type { IEnvVar, IExample, IOption } from "../types.ts";
 import { Type } from "../type.ts";
 
-export interface HelpOptions {
+export interface HelpGeneratorOptions {
   types?: boolean;
   hints?: boolean;
   colors?: boolean;
@@ -27,14 +27,14 @@ export interface HelpOptions {
 /** Help text generator. */
 export class HelpGenerator {
   private indent = 2;
-  private options: Required<HelpOptions>;
+  private options: Required<HelpGeneratorOptions>;
 
   /** Generate help text for given command. */
-  public static generate(cmd: Command, options?: HelpOptions): string {
+  public static generate(cmd: Command, options?: HelpGeneratorOptions): string {
     return new HelpGenerator(cmd, options).generate();
   }
 
-  private constructor(private cmd: Command, options: HelpOptions = {}) {
+  private constructor(private cmd: Command, options: HelpGeneratorOptions = {}) {
     this.options = {
       types: false,
       hints: true,


### PR DESCRIPTION
As per #273

Whilst making an interactive cli I found it usefull for user to be able to run --help on commands.

Without something like this the process will exit.

This change keeps all current default behaviour, and is now implemented as suggested as an option in the HelpOptions object passed to the `help()` function on a command.

Example code:

```javascript
  const text = Input.prompt({message: "Server"});

  Cliffy.Command()
      .throwErrors()
      .help({exit:false})
      ...
      .parse(command.split(" "));
```

example of it in use:

![ezgif-2-88245460975c](https://user-images.githubusercontent.com/44343744/130157044-3b853d8b-ec4e-4d83-9e21-429aad399c0a.gif)