### PR TITLE
feat(command): dedent description for better multiline support

### DIFF
--- a/command/_utils.ts
+++ b/command/_utils.ts
@@ -1,8 +1,8 @@
-import { didYouMean } from "../flags/_utils.ts";
 import {
   ArgumentFollowsVariadicArgument,
   RequiredArgumentFollowsOptionalArgument,
 } from "../flags/_errors.ts";
+import { didYouMean } from "../flags/_utils.ts";
 import { OptionType } from "../flags/types.ts";
 import type { Command } from "./command.ts";
 import type { IArgument } from "./types.ts";
@@ -129,4 +129,31 @@ export function parseArgumentsDefinition<T extends boolean>(
   return argumentDetails as (
     T extends true ? Array<IArgument | string> : Array<IArgument>
   );
+}
+
+export function dedent(str: string): string {
+  const lines = str.split(/\r?\n|\r/g);
+  let text = "";
+  let indent = 0;
+
+  for (const line of lines) {
+    if (text || line.trim()) {
+      if (!text) {
+        text = line.trimStart();
+        indent = line.length - text.length;
+      } else {
+        text += line.slice(indent);
+      }
+      text += "\n";
+    }
+  }
+
+  return text.trimEnd();
+}
+
+export function getDescription(
+  description: string,
+  short?: boolean,
+): string {
+  return short ? description.trim().split("\n", 1)[0] : dedent(description);
 }

--- a/command/command.ts
+++ b/command/command.ts
@@ -6,7 +6,11 @@ import {
 import { MissingRequiredEnvVar } from "./_errors.ts";
 import { parseFlags } from "../flags/flags.ts";
 import type { IDefaultValue, IFlagsResult } from "../flags/types.ts";
-import { parseArgumentsDefinition, splitArguments } from "./_utils.ts";
+import {
+  getDescription,
+  parseArgumentsDefinition,
+  splitArguments,
+} from "./_utils.ts";
 import { blue, bold, red, yellow } from "./deps.ts";
 import {
   CommandExecutableNotFound,
@@ -1590,9 +1594,7 @@ export class Command<
 
   /** Get short command description. This is the first line of the description. */
   public getShortDescription(): string {
-    return this.getDescription()
-      .trim()
-      .split("\n", 1)[0];
+    return getDescription(this.getDescription(), true);
   }
 
   /** Get original command-line arguments. */

--- a/command/completions/_fish_completions_generator.ts
+++ b/command/completions/_fish_completions_generator.ts
@@ -1,3 +1,4 @@
+import { getDescription } from "../_utils.ts";
 import type { Command } from "../command.ts";
 import type { IArgument, IOption } from "../types.ts";
 import { FileType } from "../types/file.ts";
@@ -99,7 +100,7 @@ ${this.generateCompletions(this.cmd).trim()}`;
       ?.replace(/^(-)+/, "");
 
     return this.complete(command, {
-      description: option.description,
+      description: getDescription(option.description),
       shortOption: shortOption,
       longOption: longOption,
       // required: option.requiredValue,
@@ -130,7 +131,7 @@ ${this.generateCompletions(this.cmd).trim()}`;
       cmd.push("-a", options.arguments);
     }
     options.description &&
-      cmd.push("-d", `'${options.description.split("\n", 1)[0]}'`);
+      cmd.push("-d", `'${getDescription(options.description, true)}'`);
     return cmd.join(" ");
   }
 

--- a/command/completions/_zsh_completions_generator.ts
+++ b/command/completions/_zsh_completions_generator.ts
@@ -1,3 +1,4 @@
+import { getDescription } from "../_utils.ts";
 import type { Command } from "../command.ts";
 import type { IArgument, IOption, IType } from "../types.ts";
 import { FileType } from "../types/file.ts";
@@ -276,13 +277,8 @@ function _${replaceSpecialChars(path)}() {` +
       }
     }
 
-    let description: string = option.description
-      .trim()
-      .split("\n")
-      .shift() as string;
-
-    // escape brackets and quotes
-    description = description
+    const description: string = getDescription(option.description, true)
+      // escape brackets and quotes
       .replace(/\[/g, "\\[")
       .replace(/]/g, "\\]")
       .replace(/"/g, '\\"')

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -1,6 +1,6 @@
 import { getFlag } from "../../flags/_utils.ts";
 import { Table } from "../../table/table.ts";
-import { parseArgumentsDefinition } from "../_utils.ts";
+import { dedent, getDescription, parseArgumentsDefinition } from "../_utils.ts";
 import type { Command } from "../command.ts";
 import {
   blue,
@@ -14,9 +14,8 @@ import {
   setColorEnabled,
   yellow,
 } from "../deps.ts";
-import type { IArgument } from "../types.ts";
-import type { IEnvVar, IExample, IOption } from "../types.ts";
 import { Type } from "../type.ts";
+import type { IArgument, IEnvVar, IExample, IOption } from "../types.ts";
 
 export interface HelpOptions {
   types?: boolean;
@@ -118,7 +117,7 @@ export class HelpGenerator {
     }
     return this.label("Description") +
       Table.from([
-        [this.cmd.getDescription()],
+        [dedent(this.cmd.getDescription())],
       ])
         .indent(this.indent * 2)
         .maxColWidth(140)
@@ -180,9 +179,7 @@ export class HelpGenerator {
               this.options.types,
             ),
             red(bold("-")),
-            this.options.long
-              ? option.description
-              : option.description.split("\n", 1)[0],
+            getDescription(option.description, !this.options.long),
             this.generateHints(option),
           ]),
         ])
@@ -198,9 +195,7 @@ export class HelpGenerator {
         ...group.options.map((option: IOption) => [
           option.flags.map((flag) => blue(flag)).join(", "),
           red(bold("-")),
-          this.options.long
-            ? option.description
-            : option.description.split("\n", 1)[0],
+          getDescription(option.description, !this.options.long),
           this.generateHints(option),
         ]),
       ])
@@ -274,8 +269,8 @@ export class HelpGenerator {
           ),
           red(bold("-")),
           this.options.long
-            ? envVar.description
-            : envVar.description.split("\n", 1)[0],
+            ? dedent(envVar.description)
+            : envVar.description.trim().split("\n", 1)[0],
         ]),
       ])
         .padding([2, 2, 1])
@@ -293,7 +288,7 @@ export class HelpGenerator {
     return this.label("Examples") +
       Table.from(examples.map((example: IExample) => [
         dim(bold(`${capitalize(example.name)}:`)),
-        example.description,
+        dedent(example.description),
       ]))
         .padding(1)
         .indent(this.indent * 2)

--- a/command/test/integration/command.ts
+++ b/command/test/integration/command.ts
@@ -4,7 +4,12 @@ import { EnumType } from "../../types/enum.ts";
 const cmd = new Command()
   .version("1.0.0")
   .name("completions-test")
-  .description("Completions test.")
+  .description(`
+    Completions test.
+    
+      Completions test.
+    Completions test.
+  `)
   .meta("meta1", "value1")
   .meta("meta2", "value2")
   .meta("meta3", "value3")
@@ -12,7 +17,13 @@ const cmd = new Command()
   .globalOption("-g, --global <val:boolean>", "Foo option.")
   .option(
     "-m, --main <val:boolean>",
-    "Bar option.\nfoo bar baz. foo bar baz.\n\nfoo bar baz.\nfoo bar baz.",
+    `
+          Bar option.
+            foo bar baz. foo bar baz.
+          
+          foo bar baz.
+          foo bar baz.
+  `,
   )
   .option("-c, --color <val:color>", "Color option.")
   .option("-C, --colors <val...:color>", "Color option.")

--- a/command/test/integration/fixtures/help_command.out
+++ b/command/test/integration/fixtures/help_command.out
@@ -8,7 +8,10 @@
 
   [1mDescription:[22m
 
-    Completions test.
+    Completions test.  
+                       
+      Completions test.
+    Completions test.  
 
   [1mOptions:[22m
 

--- a/command/test/integration/fixtures/help_option_long.out
+++ b/command/test/integration/fixtures/help_option_long.out
@@ -8,7 +8,10 @@
 
   [1mDescription:[22m
 
-    Completions test.
+    Completions test.  
+                       
+      Completions test.
+    Completions test.  
 
   [1mOptions:[22m
 
@@ -16,7 +19,7 @@
     [34m-V[39m, [34m--version[39m            [31m[1m-[22m[39m Show the version number for this program.                                   
     [34m-g[39m, [34m--global[39m   [33m<[39m[35mval[39m[33m>[39m     [31m[1m-[22m[39m Foo option.                                                                 
     [34m-m[39m, [34m--main[39m     [33m<[39m[35mval[39m[33m>[39m     [31m[1m-[22m[39m Bar option.                                                                 
-                               foo bar baz. foo bar baz.                                                   
+                                 foo bar baz. foo bar baz.                                                 
                                                                                                            
                                foo bar baz.                                                                
                                foo bar baz.                                                                

--- a/command/test/integration/fixtures/help_option_short.out
+++ b/command/test/integration/fixtures/help_option_short.out
@@ -8,7 +8,10 @@
 
   [1mDescription:[22m
 
-    Completions test.
+    Completions test.  
+                       
+      Completions test.
+    Completions test.  
 
   [1mOptions:[22m
 

--- a/command/test/integration/update_fixtures.ts
+++ b/command/test/integration/update_fixtures.ts
@@ -1,11 +1,16 @@
 import { expandGlob } from "../../../dev_deps.ts";
 import { baseDir, runCommand } from "./utils.ts";
 
+const promises = [];
 for await (const file of expandGlob(`${baseDir}/fixtures/*.in`)) {
-  if (file.isFile) {
-    const outPath = file.path.replace(/\.in$/, ".out");
-    const cmd = await Deno.readTextFile(file.path);
-    const output: string = await runCommand(cmd.split(" "));
-    await Deno.writeTextFile(outPath, output);
-  }
+  promises.push((async () => {
+    if (file.isFile) {
+      const outPath = file.path.replace(/\.in$/, ".out");
+      const cmd = await Deno.readTextFile(file.path);
+      const output: string = await runCommand(cmd.split(" "));
+      await Deno.writeTextFile(outPath, output);
+    }
+  })());
 }
+
+await Promise.all(promises);


### PR DESCRIPTION
Dedent description for better multiline formatting.
```ts
new Command()
  .description(
    `
      Foo bar baz
        Foo bar baz

      Foo bar baz
    `
  )
```
Output:
```console
Foo bar baz
  Foo bar baz

Foo bar baz
```