### PR TITLE
Explicitly scope Fish variables

### DIFF
--- a/command/completions/_fish_completions_generator.ts
+++ b/command/completions/_fish_completions_generator.ts
@@ -33,22 +33,22 @@ export class FishCompletionsGenerator {
 # fish completion support for ${path}${version}
 
 function __fish_${replaceSpecialChars(this.cmd.getName())}_using_command
-  set cmds ${getCommandFnNames(this.cmd).join(" ")}
-  set words (commandline -opc)
-  set cmd "_"
+  set -l cmds ${getCommandFnNames(this.cmd).join(" ")}
+  set -l words (commandline -opc)
+  set -l cmd "_"
   for word in $words
     switch $word
       case '-*'
         continue
       case '*'
         set word (string replace -r -a '\\W' '_' $word)
-        set cmd_tmp $cmd"_$word"
+        set -l cmd_tmp $cmd"_$word"
         if contains $cmd_tmp $cmds
           set cmd $cmd_tmp
         end
     end
   end
-  if [ "$cmd" = "$argv[1]" ]
+  if test "$cmd" = "$argv[1]"
     return 0
   end
   return 1

--- a/command/test/integration/__snapshots__/test.ts.snap
+++ b/command/test/integration/__snapshots__/test.ts.snap
@@ -309,22 +309,22 @@ snapshot[`command integration > should generate fish completions 1`] = `
 # fish completion support for completions-test v1.0.0
 
 function __fish_completions_test_using_command
-  set cmds __completions_test __completions_test_foo __completions_test_help __completions_test_foo_bar __completions_test_help __completions_test_help __completions_test_completions __completions_test_help __completions_test_completions_bash __completions_test_help __completions_test_completions_fish __completions_test_help __completions_test_completions_zsh __completions_test_help
-  set words (commandline -opc)
-  set cmd "_"
+  set -l cmds __completions_test __completions_test_foo __completions_test_help __completions_test_foo_bar __completions_test_help __completions_test_help __completions_test_completions __completions_test_help __completions_test_completions_bash __completions_test_help __completions_test_completions_fish __completions_test_help __completions_test_completions_zsh __completions_test_help
+  set -l words (commandline -opc)
+  set -l cmd "_"
   for word in \$words
     switch \$word
       case '-*'
         continue
       case '*'
         set word (string replace -r -a '\\\\W' '_' \$word)
-        set cmd_tmp \$cmd"_\$word"
+        set -l cmd_tmp \$cmd"_\$word"
         if contains \$cmd_tmp \$cmds
           set cmd \$cmd_tmp
         end
     end
   end
-  if [ "\$cmd" = "\$argv[1]" ]
+  if test "\$cmd" = "\$argv[1]"
     return 0
   end
   return 1


### PR DESCRIPTION
This avoids accidentally overwriting global variables with the same name.

Also changed one `[` to more idiomatic `test`.