### PR TITLE
Fix examples

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -124,6 +124,7 @@ export class Command<
 
   /** Disable version option. */
   public versionOption(enable: false): this;
+
   /**
    * Set global version option.
    * @param flags The flags of the version option.
@@ -137,6 +138,7 @@ export class Command<
       global: true;
     },
   ): this;
+
   /**
    * Set version option.
    * @param flags The flags of the version option.
@@ -148,6 +150,7 @@ export class Command<
     desc?: string,
     opts?: ICommandOption<CO, CA, CG, CPG, CT, CGT, CPT, CP>,
   ): this;
+
   /**
    * Set version option.
    * @param flags The flags of the version option.
@@ -159,6 +162,7 @@ export class Command<
     desc?: string,
     opts?: IAction<CO, CA, CG, CPG, CT, CGT, CPT, CP>,
   ): this;
+
   public versionOption(
     flags: string | false,
     desc?: string,
@@ -179,6 +183,7 @@ export class Command<
 
   /** Disable help option. */
   public helpOption(enable: false): this;
+
   /**
    * Set global help option.
    * @param flags The flags of the help option.
@@ -192,6 +197,7 @@ export class Command<
       global: true;
     },
   ): this;
+
   /**
    * Set help option.
    * @param flags The flags of the help option.
@@ -203,6 +209,7 @@ export class Command<
     desc?: string,
     opts?: ICommandOption<CO, CA, CG, CPG, CT, CGT, CPT, CP>,
   ): this;
+
   /**
    * Set help option.
    * @param flags The flags of the help option.
@@ -214,6 +221,7 @@ export class Command<
     desc?: string,
     opts?: IAction<CO, CA, CG, CPG, CT, CGT, CPT, CP>,
   ): this;
+
   public helpOption(
     flags: string | false,
     desc?: string,
@@ -680,7 +688,8 @@ export class Command<
     complete: ICompleteHandler<CO, CA, CG, CPG, CT, CGT, CPT, CP>,
     options?: ICompleteOptions,
   ): this;
-  complete(
+
+  public complete(
     name: string,
     complete:
       | ICompleteHandler<CO, CA, CG, CPG, CT, CGT, CPT, CP>
@@ -1132,15 +1141,15 @@ export class Command<
     try {
       return await this.parseCommand({ args }) as any;
     } catch (error: unknown) {
-      if (error instanceof Error) {
-        throw this.error(error);
-      } else {
-        throw this.error(new Error(`[non-error-thrown] ${error}`));
-      }
+      this.throw(
+        error instanceof Error
+          ? error
+          : new Error(`[non-error-thrown] ${error}`),
+      );
     }
   }
 
-  private async parseCommand(ctx: ParseCommandContext): Promise<IParseResult> {
+  private async parseCommand(ctx: ParseContext): Promise<IParseResult> {
     this.reset();
     this.registerDefaults();
     this.rawArgs = ctx.args;
@@ -1183,12 +1192,15 @@ export class Command<
     if (subCommand || ctx.args.length > 0) {
       if (!subCommand) {
         subCommand = this.getCommand(ctx.args[0], true);
+
         if (subCommand) {
           ctx.args = ctx.args.slice(1);
         }
       }
+
       if (subCommand) {
         subCommand._globalParent = this;
+
         return subCommand.parseCommand(ctx);
       }
     }
@@ -1207,6 +1219,7 @@ export class Command<
     // Execute option action.
     if (ctx.action) {
       await ctx.action.action.call(this, options, ...params);
+
       if (ctx.action.standalone) {
         return {
           options,
@@ -1221,8 +1234,8 @@ export class Command<
   }
 
   private async parseGlobalOptionsAndEnvVars(
-    ctx: ParseCommandContext,
-  ): Promise<ParseCommandContext> {
+    ctx: ParseContext,
+  ): Promise<ParseContext> {
     // Parse global env vars.
     const envVars = [
       ...this.envVars.filter((envVar) => envVar.global),
@@ -1236,16 +1249,14 @@ export class Command<
       ...this.options.filter((option) => option.global),
       ...this.getGlobalOptions(true),
     ];
-    const result = this.parseOptions(ctx.args, options, env, true);
 
-    // Merge context.
-    return this.mergeContext(ctx, result, env);
+    return this.parseOptions(ctx, options, env, true);
   }
 
   private async parseOptionsAndEnvVars(
-    ctx: ParseCommandContext,
+    ctx: ParseContext,
     preParseGlobals: boolean,
-  ): Promise<ParseCommandContext> {
+  ): Promise<ParseContext> {
     // Parse env vars.
     const envVars = preParseGlobals
       ? this.envVars.filter((envVar) => !envVar.global)
@@ -1258,24 +1269,7 @@ export class Command<
       ? this.options.filter((option) => !option.global)
       : this.getOptions(true);
 
-    const result = this.parseOptions(ctx.args, options, env);
-
-    // Merge context.
-    return this.mergeContext(ctx, result, env);
-  }
-
-  private mergeContext(
-    ctx: ParseCommandContext,
-    result: ParseOptionsResult,
-    env: Record<string, unknown>,
-  ): ParseCommandContext {
-    return {
-      args: result.args,
-      options: { ...ctx.options, ...result.options },
-      env: { ...ctx.env, ...env },
-      action: ctx.action ?? result.action,
-      literal: result.literal,
-    };
+    return this.parseOptions(ctx, options, env);
   }
 
   /** Register default options like `--version` and `--help`. */
@@ -1399,6 +1393,7 @@ export class Command<
         cmd: [command, ...args],
       });
       const status: Deno.ProcessStatus = await process.status();
+
       if (!status.success) {
         Deno.exit(status.code);
       }
@@ -1415,35 +1410,40 @@ export class Command<
    * @param args Raw command line arguments.
    */
   protected parseOptions(
-    args: string[],
+    ctx: ParseContext,
     options: IOption[],
     env: Record<string, unknown>,
     stopEarly: boolean = this._stopEarly,
-  ): ParseOptionsResult {
+  ): ParseContext {
     try {
-      let actionOption: ActionOption | undefined;
-      const result = parseFlags(args, {
+      let action: ActionOption | undefined;
+
+      const parseResult = parseFlags(ctx.args, {
         stopEarly,
         allowEmpty: this._allowEmpty,
         flags: options,
         ignoreDefaults: env,
         parse: (type: ITypeInfo) => this.parseType(type),
         option: (option: IOption) => {
-          if (!actionOption && option.action) {
-            actionOption = option as ActionOption;
+          if (!action && option.action) {
+            action = option as ActionOption;
           }
         },
       });
+
+      // Merge context.
       return {
-        options: result.flags,
-        args: result.unknown,
-        literal: result.literal,
-        action: actionOption,
+        args: parseResult.unknown,
+        options: { ...ctx.options, ...parseResult.flags },
+        env: { ...ctx.env, ...env },
+        action: ctx.action ?? action,
+        literal: parseResult.literal,
       };
     } catch (error) {
       if (error instanceof FlagsValidationError) {
         throw new ValidationError(error.message);
       }
+
       throw error;
     }
   }
@@ -1532,9 +1532,12 @@ export class Command<
   /**
    * Parse command-line arguments.
    * @param args  Raw command line arguments.
-   * @param flags Parsed command line options.
+   * @param options Parsed command line options.
    */
-  protected parseArguments(args: string[], flags: Record<string, unknown>): CA {
+  protected parseArguments(
+    args: string[],
+    options: Record<string, unknown>,
+  ): CA {
     const params: Array<unknown> = [];
 
     // remove array reference
@@ -1555,8 +1558,8 @@ export class Command<
           .map((expectedArg) => expectedArg.name);
 
         if (required.length) {
-          const flagNames: string[] = Object.keys(flags);
-          const hasStandaloneOption = !!flagNames.find((name) =>
+          const optionNames: string[] = Object.keys(options);
+          const hasStandaloneOption = !!optionNames.find((name) =>
             this.getOption(name, true)?.standalone
           );
 
@@ -1618,12 +1621,14 @@ export class Command<
    * will be called.
    * @param error Error to handle.
    */
-  protected error(error: Error): Error {
+  protected throw(error: Error): never {
     if (this.shouldThrowErrors() || !(error instanceof ValidationError)) {
-      return error;
+      throw error;
     }
     this.showHelp();
+
     console.error(red(`  ${bold("error")}: ${error.message}\n`));
+
     Deno.exit(error instanceof ValidationError ? error.exitCode : 1);
   }
 
@@ -1777,21 +1782,20 @@ export class Command<
   public async checkVersion(): Promise<void> {
     const mainCommand = this.getMainCommand();
     const upgradeCommand = mainCommand.getCommand("upgrade");
-    if (isUpgradeCommand(upgradeCommand)) {
-      const latestVersion = await upgradeCommand.getLatestVersion();
-      const currentVersion = mainCommand.getVersion();
-      if (currentVersion !== latestVersion) {
-        mainCommand.version(
-          `${currentVersion}  ${
-            bold(
-              yellow(
-                `(New version available: ${latestVersion}. Run '${mainCommand.getName()} upgrade' to upgrade to the latest version!)`,
-              ),
-            )
-          }`,
-        );
-      }
+
+    if (!isUpgradeCommand(upgradeCommand)) {
+      return;
     }
+    const latestVersion = await upgradeCommand.getLatestVersion();
+    const currentVersion = mainCommand.getVersion();
+
+    if (currentVersion === latestVersion) {
+      return;
+    }
+    const versionHelpText =
+      `(New version available: ${latestVersion}. Run '${mainCommand.getName()} upgrade' to upgrade to the latest version!)`;
+
+    mainCommand.version(`${currentVersion}  ${bold(yellow(versionHelpText))}`);
   }
 
   /*****************************************************************************
@@ -2369,6 +2373,16 @@ interface IDefaultOption {
   opts?: ICommandOption;
 }
 
+type ActionOption = IOption & { action: IAction };
+
+interface ParseContext {
+  args: string[];
+  options?: Record<string, unknown>;
+  env?: Record<string, unknown>;
+  action?: ActionOption;
+  literal?: string[];
+}
+
 type TrimLeft<T extends string, V extends string | undefined> = T extends
   `${V}${infer U}` ? U
   : T;
@@ -2758,69 +2772,3 @@ type Spread<L, R> = L extends void ? R : R extends void ? L
 >;
 
 type ValueOf<T> = T extends Record<string, infer V> ? ValueOf<V> : T;
-
-type ActionOption = IOption & { action: IAction };
-
-type ParseOptionsResult = {
-  options: Record<string, unknown>;
-  args: Array<string>;
-  literal: Array<string>;
-  action?: ActionOption;
-};
-
-interface ParseCommandContext {
-  args: string[];
-  options?: Record<string, unknown>;
-  env?: Record<string, unknown>;
-  action?: ActionOption;
-  literal?: string[];
-}
-
-// type ParseOptionsAndEnvVarsResult =
-//   | ParseOptionsResult & { error: null }
-//   | Record<keyof ParseOptionsResult, null> & { error: ValidationError };
-
-// type ParseGlobalOptionsAndEnvVarsResult =
-//   | ParseOptionsResult & { env: Record<string, unknown>; error: null }
-//   | Record<keyof ParseOptionsResult, null> & {
-//     env: null;
-//     error: ValidationError;
-//   };
-
-// try {
-//   return {
-//     ...this.parseOptions(this.rawArgs, options, parsedEnv, true),
-//     env: parsedEnv,
-//     error: null,
-//   };
-// } catch (error) {
-//   if (!(error instanceof ValidationError)) {
-//     throw error;
-//   }
-//   return {
-//     flags: null,
-//     unknown: null,
-//     actionOption: null,
-//     literal: null,
-//     env: null,
-//     error,
-//   };
-// }
-
-// try {
-//   return {
-//     ...this.parseOptions(args, options, parsedEnv),
-//     error: null,
-//   };
-// } catch (error) {
-//   if (!(error instanceof ValidationError)) {
-//     throw error;
-//   }
-//   return {
-//     flags: null,
-//     unknown: null,
-//     actionOption: null,
-//     literal: null,
-//     error,
-//   };
-// }

--- a/examples/ansi.ts
+++ b/examples/ansi.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --unstable
 
-import { colors, tty } from "https://deno.land/x/cliffy@v0.24.3/ansi/mod.ts";
+import { colors, tty } from "../ansi/mod.ts";
 
 const error = colors.bold.red;
 const warn = colors.bold.yellow;

--- a/examples/ansi.ts
+++ b/examples/ansi.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --unstable
 
-import { colors, tty } from "https://deno.land/x/cliffy@v0.20.1/ansi/mod.ts";
+import { colors, tty } from "https://deno.land/x/cliffy@v0.24.3/ansi/mod.ts";
 
 const error = colors.bold.red;
 const warn = colors.bold.yellow;

--- a/examples/command.ts
+++ b/examples/command.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-net=localhost:8080,deno.land
 
-import { Command } from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
+import { Command } from "https://deno.land/x/cliffy@v0.24.3/command/mod.ts";
 import { serve } from "https://deno.land/std@0.150.0/http/server.ts";
 
 await new Command()
@@ -10,7 +10,7 @@ await new Command()
   .option("-p, --port <port:number>", "The port number for the local server.", {
     default: 8080,
   })
-  .option("-h, --host [hostname]", "The host name for the local server.", {
+  .option("--host <hostname>", "The host name for the local server.", {
     default: "localhost",
   })
   .arguments("[domain]")
@@ -28,6 +28,6 @@ await new Command()
         method: req.method,
         body: req.body,
       });
-    }, { addr: `${host}:${port}` });
+    }, { hostname: host, port });
   })
   .parse();

--- a/examples/command.ts
+++ b/examples/command.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-net=localhost:8080,deno.land
 
-import { Command } from "https://deno.land/x/cliffy@v0.24.3/command/mod.ts";
+import { Command } from "../command/mod.ts";
 import { serve } from "https://deno.land/std@0.150.0/http/server.ts";
 
 await new Command()

--- a/examples/flags.ts
+++ b/examples/flags.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { parseFlags } from "https://deno.land/x/cliffy@v0.20.1/flags/mod.ts";
+import { parseFlags } from "https://deno.land/x/cliffy@v0.24.3/flags/mod.ts";
 
 const { flags } = parseFlags(Deno.args, {
   stopEarly: true,

--- a/examples/flags.ts
+++ b/examples/flags.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { parseFlags } from "https://deno.land/x/cliffy@v0.24.3/flags/mod.ts";
+import { parseFlags } from "../flags/mod.ts";
 
 const { flags } = parseFlags(Deno.args, {
   stopEarly: true,

--- a/examples/keycode.ts
+++ b/examples/keycode.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env -S deno run --unstable
 
-import {
-  KeyCode,
-  parse,
-} from "https://deno.land/x/cliffy@v0.24.3/keycode/mod.ts";
+import { KeyCode, parse } from "../keycode/mod.ts";
 
 while (true) {
   const data = new Uint8Array(8);

--- a/examples/keycode.ts
+++ b/examples/keycode.ts
@@ -3,7 +3,7 @@
 import {
   KeyCode,
   parse,
-} from "https://deno.land/x/cliffy@v0.20.1/keycode/mod.ts";
+} from "https://deno.land/x/cliffy@v0.24.3/keycode/mod.ts";
 
 while (true) {
   const data = new Uint8Array(8);

--- a/examples/keypress.ts
+++ b/examples/keypress.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env -S deno run --unstable
 
-import {
-  keypress,
-  KeyPressEvent,
-} from "https://deno.land/x/cliffy@v0.24.3/keypress/mod.ts";
+import { keypress, KeyPressEvent } from "../keypress/mod.ts";
 
 /** Promise */
 const event: KeyPressEvent = await keypress();

--- a/examples/keypress.ts
+++ b/examples/keypress.ts
@@ -3,7 +3,7 @@
 import {
   keypress,
   KeyPressEvent,
-} from "https://deno.land/x/cliffy@v0.20.1/keypress/mod.ts";
+} from "https://deno.land/x/cliffy@v0.24.3/keypress/mod.ts";
 
 /** Promise */
 const event: KeyPressEvent = await keypress();

--- a/examples/prompt.ts
+++ b/examples/prompt.ts
@@ -5,7 +5,7 @@ import {
   Input,
   Number,
   Secret,
-} from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
+} from "https://deno.land/x/cliffy@v0.24.3/prompt/mod.ts";
 
 let hostname: string, port: number, password: string;
 

--- a/examples/prompt.ts
+++ b/examples/prompt.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env -S deno run --unstable
 
-import {
-  Confirm,
-  Input,
-  Number,
-  Secret,
-} from "https://deno.land/x/cliffy@v0.24.3/prompt/mod.ts";
+import { Confirm, Input, Number, Secret } from "../prompt/mod.ts";
 
 let hostname: string, port: number, password: string;
 

--- a/examples/table.ts
+++ b/examples/table.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { Cell, Table } from "https://deno.land/x/cliffy@v0.20.1/table/mod.ts";
+import { Cell, Table } from "https://deno.land/x/cliffy@v0.24.3/table/mod.ts";
 
 const table = new Table(
   [

--- a/examples/table.ts
+++ b/examples/table.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { Cell, Table } from "https://deno.land/x/cliffy@v0.24.3/table/mod.ts";
+import { Cell, Table } from "../table/mod.ts";
 
 const table = new Table(
   [


### PR DESCRIPTION
I noticed the example "command.ts" script on https://cliffy.io wasn't working.

deno run --allow-net https://deno.land/x/cliffy/examples/command.ts

```
➜  deno-cliffy git:(main) deno run --allow-net https://deno.land/x/cliffy/examples/command.ts
Check https://deno.land/x/cliffy/examples/command.ts
error: TS2345 [ERROR]: Argument of type '{ addr: string; }' is not assignable to parameter of type 'ServeInit'.
  Object literal may only specify known properties, and 'addr' does not exist in type 'ServeInit'.
    }, { addr: `${host}:${port}` });
         ~~~~~~~~~~~~~~~~~~~~~~~
    at https://deno.land/x/cliffy@v0.24.3/examples/command.ts:31:10
```

I fixed the issue (replaced `{ addr: }` with `{ hostname:, port:}`) and upgraded the version of the import in the script to match the latest production version, but that introduced some new typescript errors:

1. `.option("-h, --host [hostname]")` causes `host` to be typed as `string | true`, which is not compatible with `hostname: string | undefined` in `ServeInit`. So I changed it to `<hostname>`.
2. `-h` conflicts with the default "help" argument, which throws an error, so I dropped the `-h` and left `--host`. (seems like I should be able to override `help`, so I created a separate issue here: https://github.com/c4spar/deno-cliffy/issues/411)

I also manually upgraded the version number for each example script, which didn't break anything. 😄 

