### PR TITLE
fix(command): help no longer triggers error text for missing env vars

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -1476,8 +1476,8 @@ export class Command<
     }
   }
 
-  /** 
-   * Read and validate environment variables. 
+  /**
+   * Read and validate environment variables.
    * @param envVars env vars defined by the command
    * @param validate when true, throws an error if a required env var is missing
    */

--- a/command/test/command/env_var_test.ts
+++ b/command/test/command/env_var_test.ts
@@ -104,6 +104,15 @@ Deno.test("[command] - env var - missing required env var", async () => {
   );
 });
 
+Deno.test("[command] - env var - ignores required env vars for help", async () => {
+  await new Command()
+    .throwErrors()
+    .env("foo", "...", { required: true })
+    // override default help action so Deno.exit() isn't called
+    .helpOption("", undefined, { action: () => {} })
+    .parse(["--help"]);
+});
+
 Deno.test("[command] - env var - should map the value", async () => {
   setupEnv();
   const { options } = await new Command()

--- a/command/test/command/env_var_test.ts
+++ b/command/test/command/env_var_test.ts
@@ -106,10 +106,8 @@ Deno.test("[command] - env var - missing required env var", async () => {
 
 Deno.test("[command] - env var - ignores required env vars for help", async () => {
   await new Command()
-    .throwErrors()
+    .noExit()
     .env("foo", "...", { required: true })
-    // override default help action so Deno.exit() isn't called
-    .helpOption("", undefined, { action: () => {} })
     .parse(["--help"]);
 });
 

--- a/command/test/command/env_var_test.ts
+++ b/command/test/command/env_var_test.ts
@@ -111,6 +111,14 @@ Deno.test("[command] - env var - ignores required env vars for help", async () =
     .parse(["--help"]);
 });
 
+Deno.test("[command] - env var - ignores required env vars for version", async () => {
+  await new Command()
+    .noExit()
+    .version("1.0.0")
+    .env("foo", "...", { required: true })
+    .parse(["--version"]);
+});
+
 Deno.test("[command] - env var - should map the value", async () => {
   setupEnv();
   const { options } = await new Command()


### PR DESCRIPTION
Test command (from #392):

```typescript
import { Command } from "./command/mod.ts";

await new Command()
  .name("sample-cli")
  .version("0.0.1")
  .env("FOO=<value:string>", "FOO", { required: true })
  .parse(Deno.args);
```

## Before 

```
  Usage:   sample-cli
  Version: 0.0.1     

  Options:

    -h, --help     - Show this help.                            
    -V, --version  - Show the version number for this program.  

  Environment variables:

    FOO  <value>  - FOO  (required)

  error: Missing required environment variable "FOO".
```

Exit code: 1

## After

```
 Usage:   sample-cli
  Version: 0.0.1     

  Options:

    -h, --help     - Show this help.                            
    -V, --version  - Show the version number for this program.  

  Environment variables:

    FOO  <value>  - FOO  (required)
```

Exit code: 0

## Rationale

The default `--help` option is treated like any other standalone option, which means that environment vars, flags, and arguments are all processed and validated before execution. A missing environment variable throws an error, which triggers the help text and causes a non-zero exit code.

This PR adds an option to `parseEnvVars` to _ignore_ missing required env vars, instead of immediately throwing an error. This is done when the parsed input indicates that the user is opening help.

Fixes #392