### PR TITLE
break(command): parse args as a flat array when arguments is defined as a single variadic variable

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -2478,14 +2478,6 @@ type RestArgs = OptionalOrRequiredValue<
   `${RestValue}`
 >;
 
-/// Any kind of rest args.
-type JustRestArgs<T extends string> =
-  | RestArgs
-  | RestArgsType<T>
-  | RestArgsTypeCompletion<T>
-  | RestArgsListType<T>
-  | RestArgsListTypeCompletion<T>;
-
 /**
  * Single arg with list type and completions.
  *

--- a/command/completions/complete.ts
+++ b/command/completions/complete.ts
@@ -7,7 +7,7 @@ export class CompleteCommand extends Command<
   void,
   void,
   void,
-  [action: string, commandNames?: Array<string>]
+  [action: string, ...commandNames: Array<string>]
 > {
   public constructor(cmd?: Command) {
     super();
@@ -16,7 +16,7 @@ export class CompleteCommand extends Command<
         "Get completions for given action from given command.",
       )
       .arguments("<action:string> [command...:string]")
-      .action(async (_, action: string, commandNames?: Array<string>) => {
+      .action(async (_, action: string, ...commandNames: Array<string>) => {
         let parent: Command | undefined;
         const completeCommand: Command = commandNames
           ?.reduce((cmd: Command, name: string): Command => {

--- a/command/test/command/arguments_test.ts
+++ b/command/test/command/arguments_test.ts
@@ -60,6 +60,15 @@ describe("command arguments", () => {
     assertEquals(args, ["abc", 123, true, "red", [1, 2, 3, 4]]);
   });
 
+  it("should parse correctly an isolated variadic argument", async () => {
+    const { args } = await new Command()
+      .throwErrors()
+      .arguments("<...foo:string>")
+      .parse(["foo", "bar", "baz"]);
+
+    assertEquals(args, ["foo", "bar", "baz"]);
+  });
+
   it("should parse correctly argument types with sub command arguments", async () => {
     const { args } = await cmd2().parse([
       "foo",

--- a/command/test/command/generic_types_test.ts
+++ b/command/test/command/generic_types_test.ts
@@ -512,7 +512,7 @@ import {
         .type("color", new EnumType(["red", "blue"]))
         .arguments("<...args:number>")
         .action((options, ...args) => {
-          assert<IsExact<typeof args, number[]>>(true);
+          assert<IsExact<typeof args, [number, ...Array<number>]>>(true);
           assert<
             IsExact<typeof options, void>
           >(true);
@@ -546,7 +546,7 @@ import {
               number?,
               boolean?,
               ("red" | "blue")?,
-              Array<Array<Lang>>?,
+              ...Array<Array<Lang>>,
             ]>
           >(true);
           assert<IsExact<typeof options, void>>(true);
@@ -566,7 +566,7 @@ import {
             IsExact<typeof args, [
               string,
               ("red" | "blue")?,
-              Array<Array<"js" | "rust">>?,
+              ...Array<Array<"js" | "rust">>,
             ]>
           >(true);
 
@@ -594,7 +594,7 @@ import {
       new Command()
         .command("foo <...val>")
         .action((options, ...args) => {
-          assert<IsExact<typeof args, string[]>>(true);
+          assert<IsExact<typeof args, [string, ...Array<string>]>>(true);
           assert<IsExact<typeof options, void>>(true);
         });
     },
@@ -612,7 +612,7 @@ import {
             IsExact<typeof args, [
               string,
               ("red" | "blue")?,
-              Array<Array<"js" | "rust">>?,
+              ...Array<Array<"js" | "rust">>,
             ]>
           >(true);
 

--- a/command/test/command/generic_types_test.ts
+++ b/command/test/command/generic_types_test.ts
@@ -506,6 +506,21 @@ import {
   });
 
   Deno.test({
+    name: "[command] - generic types - just a variadic arg",
+    fn() {
+      new Command()
+        .type("color", new EnumType(["red", "blue"]))
+        .arguments("<...args:number>")
+        .action((options, ...args) => {
+          assert<IsExact<typeof args, number[]>>(true);
+          assert<
+            IsExact<typeof options, void>
+          >(true);
+        });
+    },
+  });
+
+  Deno.test({
     name: "[command] - generic types - many arguments",
     fn() {
       enum Lang {
@@ -567,6 +582,19 @@ import {
         .command("foo <val:number>")
         .action((options, ...args) => {
           assert<IsExact<typeof args, [number]>>(true);
+          assert<IsExact<typeof options, void>>(true);
+        });
+    },
+  });
+
+  Deno.test({
+    name:
+      "[command] - generic types - command arguments with just a variadic argument",
+    fn() {
+      new Command()
+        .command("foo <...val>")
+        .action((options, ...args) => {
+          assert<IsExact<typeof args, string[]>>(true);
           assert<IsExact<typeof options, void>>(true);
         });
     },

--- a/command/test/command/raw_args_test.ts
+++ b/command/test/command/raw_args_test.ts
@@ -22,7 +22,7 @@ Deno.test("command - raw args - command with useRawArgs disabled", async () => {
     ]);
 
   assertEquals(options, { flag: true, scriptArg1: true, scriptArg2: true });
-  assertEquals(args, ["run", ["script-name"]]);
+  assertEquals(args, ["run", "script-name"]);
   assertEquals(literal, ["--literal-arg1", "--literal-arg2"]);
 });
 

--- a/command/test/command/stop_early_test.ts
+++ b/command/test/command/stop_early_test.ts
@@ -22,7 +22,7 @@ Deno.test("command stopEarly disable", async () => {
     ]);
 
   assertEquals(options, { flag: true, scriptArg1: true, scriptArg2: true });
-  assertEquals(args, ["run", ["script-name"]]);
+  assertEquals(args, ["run", "script-name"]);
   assertEquals(literal, ["--literal-arg1", "--literal-arg2"]);
 });
 
@@ -51,7 +51,7 @@ Deno.test("command stopEarly enabled", async () => {
   assertEquals(options, { flag: true });
   assertEquals(
     args,
-    ["run", ["script-name", "--script-arg1", "--script-arg2", "--script-arg3"]],
+    ["run", "script-name", "--script-arg1", "--script-arg2", "--script-arg3"],
   );
   assertEquals(literal, ["--literal-arg1", "--literal-arg2"]);
 });

--- a/command/test/option/variadic_test.ts
+++ b/command/test/option/variadic_test.ts
@@ -74,11 +74,7 @@ Deno.test("command optionVariadic numberInvalidValue", async () => {
 Deno.test("command optionVariadic exact", async () => {
   const { options, args } = await cmd.parse(["-v", "1", "abc", "1"]);
 
-  // @TODO: fix variadic types.
-  assertEquals(options, {
-    variadicOption: [1, "abc", true as unknown as Array<boolean>],
-  });
-  // assertEquals(options, { variadicOption: [1, "abc", [true]] });
+  assertEquals(options, { variadicOption: [1, "abc", true] });
   assertEquals(args, []);
 });
 

--- a/examples/command/arguments_syntax_variadic.ts
+++ b/examples/command/arguments_syntax_variadic.ts
@@ -4,7 +4,7 @@ import { Command } from "../../command/mod.ts";
 
 await new Command()
   .command("rmdir <dirs...:string>", "Remove directories.")
-  .action((_, dirs: string[]) => {
+  .action((_, ...dirs: [string, ...Array<string>]) => {
     dirs.forEach((dir: string) => {
       console.log("rmdir %s", dir);
     });

--- a/examples/command/stop_early.ts
+++ b/examples/command/stop_early.ts
@@ -4,9 +4,9 @@ import { Command } from "../../command/command.ts";
 
 await new Command()
   .option("-d, --debug-level <level:string>", "Debug level.")
-  .arguments("[script] [args...]")
+  .arguments("[script] [...args]")
   .stopEarly() // <-- enable stop early
-  .action((options, script?: string, args?: Array<string>) => {
+  .action((options, script?: string, ...args: Array<string>) => {
     console.log("options:", options);
     console.log("script:", script);
     console.log("args:", args);

--- a/examples/command/variadic_arguments.ts
+++ b/examples/command/variadic_arguments.ts
@@ -2,12 +2,10 @@
 
 import { Command } from "../../command/command.ts";
 
-const { args } = await new Command()
+const { args: dirs } = await new Command()
   .description("Remove directories.")
   .arguments("<dirs...>")
   .parse(Deno.args);
-
-const dirs = args[0];
 
 for (const dir of dirs) {
   console.log("rmdir %s", dir);


### PR DESCRIPTION
resolves #338

This is technically a breaking change, but only in the case where a command is defined with a single variadic argument.

Give this command definition:

```ts
const { args } = await new Command()
  .arguments("<...myArgs>")
  .parse(Deno.args);

console.log(args);
```

## Before

`args` is a nested array `[string[]]`

```sh
$ deno run ./parse_me.ts one two three
> [ [ "one", "two", "three" ] ]
```

## After

`args` is a flat array `string[]`

```sh
$ deno run ./parse_me.ts one two three
> [ "one", "two", "three" ]
```