### PR TITLE
fix(prompt): output to stderr instead of stdout

### DIFF
--- a/ansi/cursor_position.ts
+++ b/ansi/cursor_position.ts
@@ -23,7 +23,7 @@ export interface CursorPositionOptions {
 export function getCursorPosition(
   {
     stdin = Deno.stdin,
-    stdout = Deno.stdout,
+    stdout = Deno.stderr,
   }: CursorPositionOptions = {},
 ): Cursor {
   const data = new Uint8Array(8);

--- a/ansi/tty.ts
+++ b/ansi/tty.ts
@@ -42,7 +42,7 @@ export const tty: Tty = factory();
 function factory(options?: TtyOptions): Tty {
   let result = "";
   let stack: Array<[Property, Args]> = [];
-  const stdout: Deno.WriterSync = options?.stdout ?? Deno.stdout;
+  const stdout: Deno.WriterSync = options?.stdout ?? Deno.stderr;
   const stdin: Deno.ReaderSync & { rid: number } = options?.stdin ?? Deno.stdin;
 
   const tty: Tty = function (

--- a/examples/prompt/input.ts
+++ b/examples/prompt/input.ts
@@ -1,7 +1,15 @@
-#!/usr/bin/env -S deno run --unstable
+#!/usr/bin/env -S deno run --unstable --allow-net
 
 import { Input } from "../../prompt/input.ts";
 
-const name: string = await Input.prompt("What's your github user name?");
+const username: string = await Input.prompt("What's your github user name?");
 
-console.log({ name });
+const response = await fetch(`https://api.github.com/users/${username}`, {
+  headers: {
+    "Accept": "application/vnd.github+json",
+  },
+});
+
+const body = await response.text();
+
+console.log(body);

--- a/prompt/_generic_prompt.ts
+++ b/prompt/_generic_prompt.ts
@@ -123,7 +123,7 @@ export abstract class GenericPrompt<
       this.#value,
     );
     if (successMessage) {
-      console.log(successMessage);
+      console.error(successMessage);
     }
 
     GenericPrompt.injectedValue = undefined;
@@ -160,10 +160,10 @@ export abstract class GenericPrompt<
     this.#isFirstRun = false;
 
     if (Deno.build.os === "windows") {
-      console.log(content);
+      console.error(content);
       this.tty.cursorUp();
     } else {
-      Deno.stdout.writeSync(this.#encoder.encode(content));
+      Deno.stderr.writeSync(this.#encoder.encode(content));
     }
 
     if (y) {
@@ -388,7 +388,7 @@ type setRaw = (
 
 function getColumns(): number | null {
   try {
-    return Deno.consoleSize(Deno.stdout.rid).columns;
+    return Deno.consoleSize(Deno.stderr.rid).columns;
   } catch (_error) {
     return null;
   }

--- a/prompt/test/integration/test.ts
+++ b/prompt/test/integration/test.ts
@@ -61,7 +61,7 @@ async function runPrompt(file: WalkEntry): Promise<string> {
   const flags = getCmdFlagsForFile(file);
   const process = Deno.run({
     stdin: "piped",
-    stdout: "piped",
+    stderr: "piped",
     cmd: [
       "deno",
       "run",
@@ -74,7 +74,7 @@ async function runPrompt(file: WalkEntry): Promise<string> {
   });
 
   const [output, bytesCopied] = await Promise.all([
-    process.output(),
+    process.stderrOutput(),
     copy(inputFile, process.stdin),
   ]);
   inputFile.close();


### PR DESCRIPTION
The rationale is that using stderr allows you to chain actual command output together with pipes. I updated `examples/prompt/input.ts` to demonstrate what I mean. Putting prompt output on stderr allows you to pipe the JSON body to stdout for use with other tools, like `jq`:
```bash
$ ./examples/prompt/input.ts | jq .name
 ? What's your github user name? › crooke
"Eric Crook"
```
Otherwise, the prompt output will get piped into `jq` and the terminal will be blank and appear to hang.