### PR TITLE
fix(command): escape single quotes in command description for zsh completions

### DIFF
--- a/command/completions/_zsh_completions_generator.ts
+++ b/command/completions/_zsh_completions_generator.ts
@@ -100,7 +100,11 @@ function _${replaceSpecialChars(path)}() {` +
 
     let completions: string = commands
       .map((subCommand: Command) =>
-        `'${subCommand.getName()}:${subCommand.getShortDescription()}'`
+        `'${subCommand.getName()}:${
+          subCommand.getShortDescription()
+            // escape single quotes
+            .replace(/'/g, "'\"'\"'")
+        }'`
       )
       .join("\n      ");
 


### PR DESCRIPTION
Command descriptions with single quotes broke zsh completions. For an example, see https://github.com/meshcloud/unipipe-service-broker/pull/90