### PR TITLE
fix(flags): `equalsSign` option not working with `type` option

### DIFF
--- a/flags/flags.ts
+++ b/flags/flags.ts
@@ -208,7 +208,7 @@ function parseArgs<TFlagOptions extends FlagOptions>(
       }
 
       if (
-        opts.flags?.length && !option.args?.length &&
+        opts.flags?.length && !option.args?.length && !option.type &&
         typeof currentValue !== "undefined"
       ) {
         throw new UnexpectedOptionValueError(option.name, currentValue);

--- a/flags/test/option/equls_sign_test.ts
+++ b/flags/test/option/equls_sign_test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "../../../dev_deps.ts";
+import { parseFlags } from "../../flags.ts";
+
+Deno.test("[flags] should parse required value with equals sign", () => {
+  const { flags, unknown, literal } = parseFlags(["--foo=bar"], {
+    flags: [{
+      name: "foo",
+      type: "string",
+      equalsSign: true,
+    }],
+  });
+
+  assertEquals(flags, { foo: "bar" });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("[flags] should parse optional value with equals sign", () => {
+  const { flags, unknown, literal } = parseFlags(["--foo=bar"], {
+    flags: [{
+      name: "foo",
+      type: "string",
+      equalsSign: true,
+      optionalValue: true,
+    }],
+  });
+
+  assertEquals(flags, { foo: "bar" });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("[flags] should parse required value without equals sign", () => {
+  const { flags, unknown, literal } = parseFlags(["--foo", "bar"], {
+    flags: [{
+      name: "foo",
+      type: "string",
+      equalsSign: true,
+    }],
+  });
+
+  assertEquals(flags, { foo: "bar" });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});
+
+Deno.test("[flags] should parse optional value without equals sign as argument", () => {
+  const { flags, unknown, literal } = parseFlags(["--foo", "bar"], {
+    flags: [{
+      name: "foo",
+      type: "string",
+      equalsSign: true,
+      optionalValue: true,
+    }],
+  });
+
+  assertEquals(flags, { foo: true });
+  assertEquals(unknown, ["bar"]);
+  assertEquals(literal, []);
+});


### PR DESCRIPTION
close #469