### PR TITLE
fix(flags,command): value gets ignored if value of an option with an equals sign starts with a dash

### DIFF
--- a/flags/flags.ts
+++ b/flags/flags.ts
@@ -393,7 +393,7 @@ function parseArgs<TFlagOptions extends FlagOptions>(
             return false;
           }
           if (arg.optionalValue || arg.variadic) {
-            return nextValue[0] !== "-" ||
+            return nextValue[0] !== "-" || typeof currentValue !== "undefined" ||
               (arg.type === OptionType.NUMBER && !isNaN(Number(nextValue)));
           }
 

--- a/flags/flags.ts
+++ b/flags/flags.ts
@@ -393,7 +393,8 @@ function parseArgs<TFlagOptions extends FlagOptions>(
             return false;
           }
           if (arg.optionalValue || arg.variadic) {
-            return nextValue[0] !== "-" || typeof currentValue !== "undefined" ||
+            return nextValue[0] !== "-" ||
+              typeof currentValue !== "undefined" ||
               (arg.type === OptionType.NUMBER && !isNaN(Number(nextValue)));
           }
 

--- a/flags/test/option/equls_sign_test.ts
+++ b/flags/test/option/equls_sign_test.ts
@@ -58,3 +58,18 @@ Deno.test("[flags] should parse optional value without equals sign as argument",
   assertEquals(unknown, ["bar"]);
   assertEquals(literal, []);
 });
+
+Deno.test("[flags] should parse optional value with leading dash with equals sign", () => {
+  const { flags, unknown, literal } = parseFlags(["--foo=-bar"], {
+    flags: [{
+      name: "foo",
+      type: "string",
+      equalsSign: true,
+      optionalValue: true,
+    }],
+  });
+
+  assertEquals(flags, { foo: "-bar" });
+  assertEquals(unknown, []);
+  assertEquals(literal, []);
+});


### PR DESCRIPTION
close #466