### PR TITLE
fix: remove no longer existing `validateFlags` export from `cliffy/mod.ts`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -8,7 +8,6 @@ export {
   OptionType,
   parseFlags,
   string,
-  validateFlags,
 } from "./flags/mod.ts";
 export type {
   ArgumentOptions,


### PR DESCRIPTION
close #483