### PR TITLE
breaking(flags): remove `requiredValue` option and rename `option.args[].optionalValue` to `option.args[].optional`

### DIFF
--- a/command/_utils.ts
+++ b/command/_utils.ts
@@ -99,8 +99,7 @@ export function parseArgumentsDefinition<T extends boolean>(
     const type: string | undefined = parts[2] || OptionType.STRING;
 
     const details: Argument = {
-      optionalValue: arg[0] === "[",
-      requiredValue: arg[0] === "<",
+      optional: arg[0] === "[",
       name: parts[1],
       action: parts[3] || type,
       variadic: false,
@@ -108,7 +107,7 @@ export function parseArgumentsDefinition<T extends boolean>(
       type,
     };
 
-    if (validate && !details.optionalValue && hasOptional) {
+    if (validate && !details.optional && hasOptional) {
       throw new UnexpectedRequiredArgumentError(details.name);
     }
 

--- a/command/command.ts
+++ b/command/command.ts
@@ -34,7 +34,6 @@ import {
   UnknownCommandError,
   ValidationError,
 } from "./_errors.ts";
-import { DefaultValue, OptionValueHandler } from "./types.ts";
 import { BooleanType } from "./types/boolean.ts";
 import { FileType } from "./types/file.ts";
 import { NumberType } from "./types/number.ts";
@@ -50,6 +49,7 @@ import type {
   CompleteHandler,
   CompleteOptions,
   Completion,
+  DefaultValue,
   Description,
   EnvVar,
   EnvVarOptions,
@@ -61,6 +61,7 @@ import type {
   MapTypes,
   Option,
   OptionOptions,
+  OptionValueHandler,
   TypeDef,
   TypeOptions,
   TypeOrTypeHandler,
@@ -1295,7 +1296,7 @@ export class Command<
     opts?: OptionOptions | OptionValueHandler,
   ): Command<any> {
     if (typeof opts === "function") {
-      return this.option(flags, desc, { value: opts });
+      opts = { value: opts };
     }
 
     const result = splitArguments(flags);
@@ -1502,7 +1503,7 @@ export class Command<
 
     if (details.length > 1) {
       throw new TooManyEnvVarValuesError(name);
-    } else if (details.length && details[0].optionalValue) {
+    } else if (details.length && details[0].optional) {
       throw new UnexpectedOptionalEnvVarValueError(name);
     } else if (details.length && details[0].variadic) {
       throw new UnexpectedVariadicEnvVarValueError(name);
@@ -1974,7 +1975,7 @@ export class Command<
     } else {
       if (!args.length) {
         const required = this.getArguments()
-          .filter((expectedArg) => !expectedArg.optionalValue)
+          .filter((expectedArg) => !expectedArg.optional)
           .map((expectedArg) => expectedArg.name);
 
         if (required.length) {
@@ -1990,7 +1991,7 @@ export class Command<
       } else {
         for (const expectedArg of this.getArguments()) {
           if (!args.length) {
-            if (expectedArg.optionalValue) {
+            if (expectedArg.optional) {
               break;
             }
             throw new MissingArgumentError(expectedArg.name);

--- a/command/command.ts
+++ b/command/command.ts
@@ -54,6 +54,7 @@ import type {
   EnvVar,
   EnvVarOptions,
   EnvVarValueHandler,
+  ErrorHandler,
   Example,
   GlobalEnvVarOptions,
   GlobalOptionOptions,

--- a/command/completions/_zsh_completions_generator.ts
+++ b/command/completions/_zsh_completions_generator.ts
@@ -197,14 +197,14 @@ function _${replaceSpecialChars(path)}() {` +
             for (let i = 0; i < 5; i++) {
               args.push(
                 `${argIndex + i}${
-                  arg.optionalValue ? "::" : ":"
+                  arg.optional ? "::" : ":"
                 }${arg.name}:${fileCompletions}`,
               );
             }
           } else {
             args.push(
               `${++argIndex}${
-                arg.optionalValue ? "::" : ":"
+                arg.optional ? "::" : ":"
               }${arg.name}:${fileCompletions}`,
             );
           }
@@ -213,7 +213,7 @@ function _${replaceSpecialChars(path)}() {` +
           const action = this.addAction(arg, completionsPath);
           args.push(
             `${++argIndex}${
-              arg.optionalValue ? "::" : ":"
+              arg.optional ? "::" : ":"
             }${arg.name}:->${action.name}`,
           );
         }
@@ -271,12 +271,10 @@ function _${replaceSpecialChars(path)}() {` +
       const type = command.getType(arg.type);
       if (type && type.handler instanceof FileType) {
         const fileCompletions = this.getFileCompletions(type);
-        args += `${
-          arg.optionalValue ? "::" : ":"
-        }${arg.name}:${fileCompletions}`;
+        args += `${arg.optional ? "::" : ":"}${arg.name}:${fileCompletions}`;
       } else {
         const action = this.addAction(arg, completionsPath);
-        args += `${arg.optionalValue ? "::" : ":"}${arg.name}:->${action.name}`;
+        args += `${arg.optional ? "::" : ":"}${arg.name}:->${action.name}`;
       }
     }
 

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -384,7 +384,7 @@ function highlightArgumentDetails(
 ): string {
   let str = "";
 
-  str += yellow(arg.optionalValue ? "[" : "<");
+  str += yellow(arg.optional ? "[" : "<");
 
   let name = "";
   name += arg.name;
@@ -403,7 +403,7 @@ function highlightArgumentDetails(
     }
   }
 
-  str += yellow(arg.optionalValue ? "]" : ">");
+  str += yellow(arg.optional ? "]" : ">");
 
   return str;
 }

--- a/command/test/command/option_test.ts
+++ b/command/test/command/option_test.ts
@@ -55,23 +55,19 @@ Deno.test("command - option - option properties", () => {
   assertEquals(option.standalone, true);
   assertEquals(option.collect, true);
   assertEquals(option.default, false);
-  // @TODO: remove optionalValue & requiredValue from options interface, they are always undefined.
-  assertEquals(option.optionalValue, undefined);
-  assertEquals(option.requiredValue, undefined);
+
   assertEquals(option.args, [{
     action: "boolean",
     list: false,
     name: "baz",
-    optionalValue: false,
-    requiredValue: true,
+    optional: false,
     type: "boolean",
     variadic: false,
   }, {
     action: "string",
     list: false,
     name: "baz",
-    optionalValue: true,
-    requiredValue: false,
+    optional: true,
     type: "string",
     variadic: false,
   }]);

--- a/command/test/type/custom_test.ts
+++ b/command/test/type/custom_test.ts
@@ -3,7 +3,7 @@ import { Command } from "../../command.ts";
 import type { ArgumentValue, TypeHandler } from "../../types.ts";
 import { Type } from "../../type.ts";
 
-const email = (): TypeHandler<string> => {
+function email(): TypeHandler<string> {
   const emailRegex =
     /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
@@ -16,7 +16,7 @@ const email = (): TypeHandler<string> => {
 
     return value;
   };
-};
+}
 
 const cmd = new Command()
   .throwErrors()
@@ -75,16 +75,16 @@ Deno.test("command - type - custom - with invalid value on child command", async
   );
 });
 
-class CustomType<T extends string> extends Type<T> {
-  constructor(private formats: ReadonlyArray<T>) {
+class CustomType<TType extends string> extends Type<TType> {
+  constructor(private formats: ReadonlyArray<TType>) {
     super();
   }
 
-  parse(type: ArgumentValue): T {
-    if (!this.formats.includes(type.value as T)) {
+  parse(type: ArgumentValue): TType {
+    if (!this.formats.includes(type.value as TType)) {
       throw new Error(`invalid type: ${type.value}`);
     }
-    return type.value as T;
+    return type.value as TType;
   }
 }
 

--- a/examples/command/common_option_types.ts
+++ b/examples/command/common_option_types.ts
@@ -13,7 +13,7 @@ const { options } = await new Command()
   .option("-p, --pizza-type <type>", "Flavour of pizza.")
   // Option with required number value.
   .option("-a, --amount <amount:integer>", "Pieces of pizza.")
-  // One required and one optional command arguemnt.
+  // One required and one optional command argument.
   .arguments("<input:string> [output:string]")
   .parse(Deno.args);
 

--- a/examples/flags/flags.ts
+++ b/examples/flags/flags.ts
@@ -2,12 +2,4 @@
 
 import { parseFlags } from "../../flags/flags.ts";
 
-console.log(parseFlags(Deno.args, {
-  flags: [{
-    name: "file",
-    aliases: ["foo"],
-    type: "integer",
-    // file cannot be combined with stdin option
-    conflicts: ["stdin"],
-  }],
-}));
+console.log(parseFlags(Deno.args));

--- a/flags/_validate_flags.ts
+++ b/flags/_validate_flags.ts
@@ -17,9 +17,9 @@ import type { ArgumentOptions, FlagOptions } from "./types.ts";
  * @param opts    Parse options.
  * @param options Option name mappings: propertyName -> option
  */
-export function validateFlags<T extends FlagOptions = FlagOptions>(
+export function validateFlags<TOptions extends FlagOptions = FlagOptions>(
   ctx: ParseFlagsContext<Record<string, unknown>>,
-  opts: ParseFlagsOptions<T>,
+  opts: ParseFlagsOptions<TOptions>,
   options: Map<string, FlagOptions> = new Map(),
 ): void {
   if (!opts.flags) {
@@ -52,9 +52,9 @@ export function validateFlags<T extends FlagOptions = FlagOptions>(
   validateRequiredOptions(ctx, options, opts);
 }
 
-function validateUnknownOption<T extends FlagOptions = FlagOptions>(
+function validateUnknownOption<TOptions extends FlagOptions = FlagOptions>(
   option: FlagOptions,
-  opts: ParseFlagsOptions<T>,
+  opts: ParseFlagsOptions<TOptions>,
 ) {
   if (!getOption(opts.flags ?? [], option.name)) {
     throw new UnknownOptionError(option.name, opts.flags ?? []);
@@ -65,9 +65,9 @@ function validateUnknownOption<T extends FlagOptions = FlagOptions>(
  * Adds all default values to ctx.flags and returns a boolean object map with
  * only the default option names `{ [OptionName: string]: boolean }`.
  */
-function setDefaultValues<T extends FlagOptions = FlagOptions>(
+function setDefaultValues<TOptions extends FlagOptions = FlagOptions>(
   ctx: ParseFlagsContext<Record<string, unknown>>,
-  opts: ParseFlagsOptions<T>,
+  opts: ParseFlagsOptions<TOptions>,
 ) {
   const defaultValues: Record<string, boolean> = {};
   if (!opts.flags?.length) {
@@ -176,7 +176,7 @@ function validateRequiredValues(
 
   for (let i = 0; i < option.args.length; i++) {
     const arg: ArgumentOptions = option.args[i];
-    if (!arg.requiredValue) {
+    if (arg.optional) {
       continue;
     }
     const hasValue = isArray
@@ -189,10 +189,10 @@ function validateRequiredValues(
   }
 }
 
-function validateRequiredOptions<T extends FlagOptions = FlagOptions>(
+function validateRequiredOptions<TOptions extends FlagOptions = FlagOptions>(
   ctx: ParseFlagsContext<Record<string, unknown>>,
   options: Map<string, FlagOptions>,
-  opts: ParseFlagsOptions<T>,
+  opts: ParseFlagsOptions<TOptions>,
 ): void {
   if (!opts.flags?.length) {
     return;

--- a/flags/test/flags/dotted_options_test.ts
+++ b/flags/test/flags/dotted_options_test.ts
@@ -4,7 +4,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   flags: [{
     name: "bitrate.audio",
     aliases: ["b.a", "audio-bitrate"],

--- a/flags/test/option/aliases_test.ts
+++ b/flags/test/option/aliases_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{

--- a/flags/test/option/collect_test.ts
+++ b/flags/test/option/collect_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: false,
   flags: [{
     name: "flag",

--- a/flags/test/option/conflicts_test.ts
+++ b/flags/test/option/conflicts_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: false,
   flags: [{
     name: "type",

--- a/flags/test/option/default_test.ts
+++ b/flags/test/option/default_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: true,
   flags: [{
     name: "boolean",
@@ -132,6 +132,7 @@ Deno.test("[flags] should ignore defaults", () => {
 });
 
 Deno.test("[flags] should parse from context", () => {
+  console.log();
   const { flags, unknown, literal } = parseFlags({
     flags: { bar: true },
     unknown: ["--foo"],

--- a/flags/test/option/default_test.ts
+++ b/flags/test/option/default_test.ts
@@ -132,7 +132,6 @@ Deno.test("[flags] should ignore defaults", () => {
 });
 
 Deno.test("[flags] should parse from context", () => {
-  console.log();
   const { flags, unknown, literal } = parseFlags({
     flags: { bar: true },
     unknown: ["--foo"],

--- a/flags/test/option/depends_test.ts
+++ b/flags/test/option/depends_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: true,
   flags: [{
     name: "video-type",

--- a/flags/test/option/negatable_test.ts
+++ b/flags/test/option/negatable_test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertThrows } from "../../../dev_deps.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: true,
   flags: [{
     name: "remote",

--- a/flags/test/option/required_test.ts
+++ b/flags/test/option/required_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   flags: [{
     name: "required",
     type: OptionType.STRING,
@@ -11,11 +11,9 @@ const options = <ParseFlagsOptions> {
   }, {
     name: "required-value",
     type: OptionType.STRING,
-    requiredValue: true,
   }, {
     name: "required-default",
     type: OptionType.STRING,
-    requiredValue: true,
     default: "default",
   }],
 };

--- a/flags/test/option/requires_test.ts
+++ b/flags/test/option/requires_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: true,
   flags: [{
     name: "video-type",

--- a/flags/test/option/standalone_test.ts
+++ b/flags/test/option/standalone_test.ts
@@ -3,18 +3,14 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
-  stopEarly: false,
-  allowEmpty: false,
+const options: ParseFlagsOptions = {
   flags: [{
     name: "flag",
     aliases: ["f"],
-    type: OptionType.BOOLEAN,
     standalone: true,
   }, {
     name: "all",
     aliases: ["a"],
-    type: OptionType.BOOLEAN,
   }, {
     name: "foo-bar",
     aliases: ["f"],

--- a/flags/test/option/unknown_test.ts
+++ b/flags/test/option/unknown_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "../../../dev_deps.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   flags: [{
     name: "flag",
     aliases: ["f"],

--- a/flags/test/option/value_test.ts
+++ b/flags/test/option/value_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   flags: [{
     name: "function",
     aliases: ["f"],

--- a/flags/test/option/variadic_test.ts
+++ b/flags/test/option/variadic_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   allowEmpty: false,
   flags: [{
     name: "optional",
@@ -33,13 +33,13 @@ const options = <ParseFlagsOptions> {
       type: OptionType.NUMBER,
     }, {
       type: OptionType.STRING,
-      optionalValue: false,
+      optional: false,
     }, {
       type: OptionType.STRING,
-      optionalValue: true,
+      optional: true,
     }, {
       type: OptionType.BOOLEAN,
-      optionalValue: true,
+      optional: true,
       variadic: true,
     }],
   }],

--- a/flags/test/type/integer_test.ts
+++ b/flags/test/type/integer_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const optionalValueOptions = <ParseFlagsOptions> {
+const optionalValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{
@@ -14,7 +14,7 @@ const optionalValueOptions = <ParseFlagsOptions> {
   }],
 };
 
-const requiredValueOptions = <ParseFlagsOptions> {
+const requiredValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{

--- a/flags/test/type/no_value_test.ts
+++ b/flags/test/type/no_value_test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertThrows } from "../../../dev_deps.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const options = <ParseFlagsOptions> {
+const options: ParseFlagsOptions = {
   flags: [{
     name: "flag",
     aliases: ["f"],

--- a/flags/test/type/number_test.ts
+++ b/flags/test/type/number_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const optionalValueOptions = <ParseFlagsOptions> {
+const optionalValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{
@@ -14,7 +14,7 @@ const optionalValueOptions = <ParseFlagsOptions> {
   }],
 };
 
-const requiredValueOptions = <ParseFlagsOptions> {
+const requiredValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{

--- a/flags/test/type/string_test.ts
+++ b/flags/test/type/string_test.ts
@@ -3,7 +3,7 @@ import { OptionType } from "../../deprecated.ts";
 import { parseFlags } from "../../flags.ts";
 import type { ParseFlagsOptions } from "../../types.ts";
 
-const optionalValueOptions = <ParseFlagsOptions> {
+const optionalValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{
@@ -14,7 +14,7 @@ const optionalValueOptions = <ParseFlagsOptions> {
   }],
 };
 
-const requiredStringValueOptions = <ParseFlagsOptions> {
+const requiredStringValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{
@@ -24,7 +24,7 @@ const requiredStringValueOptions = <ParseFlagsOptions> {
   }],
 };
 
-const requiredNumberValueOptions = <ParseFlagsOptions> {
+const requiredNumberValueOptions: ParseFlagsOptions = {
   stopEarly: false,
   allowEmpty: false,
   flags: [{

--- a/flags/types.ts
+++ b/flags/types.ts
@@ -13,9 +13,10 @@ export interface ParseFlagsOptions<
 }
 
 /** Flag options. */
-export interface FlagOptions extends ArgumentOptions {
+export interface FlagOptions extends Omit<ArgumentOptions, "optional"> {
   name: string;
-  args?: ArgumentOptions[];
+  args?: Array<ArgumentOptions>;
+  optionalValue?: boolean;
   aliases?: string[];
   standalone?: boolean;
   default?: DefaultValue;
@@ -27,11 +28,10 @@ export interface FlagOptions extends ArgumentOptions {
   equalsSign?: boolean;
 }
 
-/** Flag argument definition. */
+/** Options for a flag argument. */
 export interface ArgumentOptions {
   type?: ArgumentType | string;
-  optionalValue?: boolean;
-  requiredValue?: boolean;
+  optional?: boolean;
   variadic?: boolean;
   list?: boolean;
   separator?: string;
@@ -40,21 +40,24 @@ export interface ArgumentOptions {
 /** Available build-in argument types. */
 export type ArgumentType = "string" | "boolean" | "number" | "integer";
 
-/** Default flag value */
+/** Default flag value or a callback method that returns the default value. */
 export type DefaultValue<TValue = unknown> =
   | TValue
   | DefaultValueHandler<TValue>;
 
 export type DefaultValueHandler<TValue = unknown> = () => TValue;
 
-/** Value handler for custom value processing. */
+/** A callback method for custom processing or mapping of flag values. */
 // deno-lint-ignore no-explicit-any
 export type ValueHandler<TValue = any, TReturn = TValue> = (
   val: TValue,
   previous?: TReturn,
 ) => TReturn;
 
-/** Result of the parseFlags method. */
+/**
+ * Parse result. The parse context will be returned by the `parseFlags` method
+ * and can be also passed as first argument to the `parseFlags` method.
+ */
 export interface ParseFlagsContext<
   // deno-lint-ignore no-explicit-any
   TFlags extends Record<string, any> = Record<string, any>,
@@ -68,13 +71,16 @@ export interface ParseFlagsContext<
   stopOnUnknown: boolean;
 }
 
-/** Type details. */
+/** Argument parsing informations. */
 export interface ArgumentValue {
   label: string;
-  type: string;
+  type: ArgumentType | string;
   name: string;
   value: string;
 }
 
-/** Custom type handler/parser. */
+/**
+ * Parse method for custom types. Gets the raw user input passed as argument
+ * and returns the parsed value.
+ */
 export type TypeHandler<TReturn = unknown> = (arg: ArgumentValue) => TReturn;


### PR DESCRIPTION
Before:

```ts
parseFlags(Deno.args, {
  flags: [{
    name: "foo",
    type: "boolean",
    requiredValue: true,
  }, {
    name: "bar",
    args: [{
      type: "string",
      optionalValue: true,
    }],
  }]
});
```

After:

```ts
parseFlags(Deno.args, {
  flags: [{
    name: "foo",
    type: "boolean",
    optionalValue: false,
  }, {
    name: "bar",
    args: [{
      type: "string",
      optional: true,
    }],
  }]
});
```