### PR TITLE
fix(prompt): grammar longer then to longer than

### DIFF
--- a/prompt/input.ts
+++ b/prompt/input.ts
@@ -73,10 +73,10 @@ export class Input extends GenericSuggestions<string, string, InputSettings> {
       return false;
     }
     if (value.length < this.settings.minLength) {
-      return `Value must be longer then ${this.settings.minLength} but has a length of ${value.length}.`;
+      return `Value must be longer than ${this.settings.minLength} but has a length of ${value.length}.`;
     }
     if (value.length > this.settings.maxLength) {
-      return `Value can't be longer then ${this.settings.maxLength} but has a length of ${value.length}.`;
+      return `Value can't be longer than ${this.settings.maxLength} but has a length of ${value.length}.`;
     }
     return true;
   }

--- a/prompt/list.ts
+++ b/prompt/list.ts
@@ -164,10 +164,10 @@ export class List extends GenericSuggestions<string[], string, ListSettings> {
 
     for (const val of values) {
       if (val.length < this.settings.minLength) {
-        return `Value must be longer then ${this.settings.minLength} but has a length of ${val.length}.`;
+        return `Value must be longer than ${this.settings.minLength} but has a length of ${val.length}.`;
       }
       if (val.length > this.settings.maxLength) {
-        return `Value can't be longer then ${this.settings.maxLength} but has a length of ${val.length}.`;
+        return `Value can't be longer than ${this.settings.maxLength} but has a length of ${val.length}.`;
       }
     }
 

--- a/prompt/secret.ts
+++ b/prompt/secret.ts
@@ -82,10 +82,10 @@ export class Secret extends GenericInput<string, string, SecretSettings> {
       return false;
     }
     if (value.length < this.settings.minLength) {
-      return `${this.settings.label} must be longer then ${this.settings.minLength} but has a length of ${value.length}.`;
+      return `${this.settings.label} must be longer than ${this.settings.minLength} but has a length of ${value.length}.`;
     }
     if (value.length > this.settings.maxLength) {
-      return `${this.settings.label} can't be longer then ${this.settings.maxLength} but has a length of ${value.length}.`;
+      return `${this.settings.label} can't be longer than ${this.settings.maxLength} but has a length of ${value.length}.`;
     }
     return true;
   }

--- a/prompt/test/input_test.ts
+++ b/prompt/test/input_test.ts
@@ -43,7 +43,7 @@ Deno.test("prompt input: empty value", async () => {
     red(
       `${
         Deno.build.os === "windows" ? bold(" × ") : bold(" ✘ ")
-      }Value must be longer then 8 but has a length of 0.`,
+      }Value must be longer than 8 but has a length of 0.`,
     ),
   );
 });

--- a/prompt/test/list_test.ts
+++ b/prompt/test/list_test.ts
@@ -72,7 +72,7 @@ Deno.test("prompt list: min length", async () => {
     red(
       `${
         Deno.build.os === "windows" ? bold(" × ") : bold(" ✘ ")
-      }Value must be longer then 3 but has a length of 2.`,
+      }Value must be longer than 3 but has a length of 2.`,
     ),
   );
 });
@@ -91,7 +91,7 @@ Deno.test("prompt list: max length", async () => {
     red(
       `${
         Deno.build.os === "windows" ? bold(" × ") : bold(" ✘ ")
-      }Value can't be longer then 2 but has a length of 3.`,
+      }Value can't be longer than 2 but has a length of 3.`,
     ),
   );
 });

--- a/prompt/test/secret_test.ts
+++ b/prompt/test/secret_test.ts
@@ -32,7 +32,7 @@ Deno.test("prompt secret: empty value", async () => {
     red(
       `${
         Deno.build.os === "windows" ? bold(" × ") : bold(" ✘ ")
-      }Password must be longer then 8 but has a length of 0.`,
+      }Password must be longer than 8 but has a length of 0.`,
     ),
   );
 });


### PR DESCRIPTION
Small grammar fix.

Messages like "Value must be longer **then** 1 but has a length of 0" should use "than" instead of "then", e.g. "Value must be longer **than** 1 but has a length of 0".