### PR TITLE
fix(prompt): ignore special keys like F1, escape, etc. in input prompts

### DIFF
--- a/prompt/_generic_input.ts
+++ b/prompt/_generic_input.ts
@@ -110,8 +110,8 @@ export abstract class GenericInput<
         await this.submit();
         break;
       default:
-        if (event.sequence && !event.meta && !event.ctrl) {
-          this.addChar(event.sequence);
+        if (event.char && !event.meta && !event.ctrl) {
+          this.addChar(event.char);
         }
     }
   }


### PR DESCRIPTION
close #490