### PR TITLE
feat(command): add `indent` and `compact` option to `.help()` method

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -1756,10 +1756,7 @@ export class Command<
       this.type("file", new FileType(), { global: true });
 
     if (!this._help) {
-      this.help({
-        hints: true,
-        types: false,
-      });
+      this.help({});
     }
 
     if (this._versionOptions !== false && (this._versionOptions || this.ver)) {

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -22,6 +22,8 @@ export interface HelpOptions {
   hints?: boolean;
   colors?: boolean;
   long?: boolean;
+  indent?: boolean;
+  compact?: boolean;
 }
 
 interface OptionGroup {
@@ -48,6 +50,8 @@ export class HelpGenerator {
       hints: true,
       colors: true,
       long: false,
+      indent: options.compact !== true,
+      compact: false,
       ...options,
     };
   }
@@ -66,7 +70,9 @@ export class HelpGenerator {
 
     setColorEnabled(areColorsEnabled);
 
-    return result;
+    return this.options.compact
+      ? result.replace(/^\n/, "").replace(/\n$/, "")
+      : result;
   }
 
   private generateHeader(): string {
@@ -86,7 +92,7 @@ export class HelpGenerator {
     }
     return "\n" +
       Table.from(rows)
-        .indent(this.indent)
+        .indent(this.options.indent ? this.indent : 0)
         .padding(1)
         .toString() +
       "\n";
@@ -105,7 +111,7 @@ export class HelpGenerator {
 
     return "\n" +
       Table.from(rows)
-        .indent(this.indent)
+        .indent(this.options.indent ? this.indent : 0)
         .padding(1)
         .toString() +
       "\n";
@@ -119,7 +125,7 @@ export class HelpGenerator {
       Table.from([
         [dedent(this.cmd.getDescription())],
       ])
-        .indent(this.indent * 2)
+        .indent(this.options.indent ? this.indent * 2 : this.indent)
         .maxColWidth(140)
         .padding(1)
         .toString() +
@@ -184,7 +190,7 @@ export class HelpGenerator {
           ]),
         ])
           .padding([2, 2, 1, 2])
-          .indent(this.indent * 2)
+          .indent(this.options.indent ? this.indent * 2 : this.indent)
           .maxColWidth([60, 60, 1, 80, 60])
           .toString() +
         "\n";
@@ -199,7 +205,7 @@ export class HelpGenerator {
           this.generateHints(option),
         ]),
       ])
-        .indent(this.indent * 2)
+        .indent(this.options.indent ? this.indent * 2 : this.indent)
         .maxColWidth([60, 1, 80, 60])
         .padding([2, 1, 2])
         .toString() +
@@ -231,7 +237,7 @@ export class HelpGenerator {
             command.getShortDescription(),
           ]),
         ])
-          .indent(this.indent * 2)
+          .indent(this.options.indent ? this.indent * 2 : this.indent)
           .maxColWidth([60, 60, 1, 80])
           .padding([2, 2, 1, 2])
           .toString() +
@@ -251,7 +257,7 @@ export class HelpGenerator {
       ])
         .maxColWidth([60, 1, 80])
         .padding([2, 1, 2])
-        .indent(this.indent * 2)
+        .indent(this.options.indent ? this.indent * 2 : this.indent)
         .toString() +
       "\n";
   }
@@ -277,7 +283,7 @@ export class HelpGenerator {
         ]),
       ])
         .padding([2, 2, 1, 2])
-        .indent(this.indent * 2)
+        .indent(this.options.indent ? this.indent * 2 : this.indent)
         .maxColWidth([60, 60, 1, 80, 10])
         .toString() +
       "\n";
@@ -294,7 +300,7 @@ export class HelpGenerator {
         dedent(example.description),
       ]))
         .padding(1)
-        .indent(this.indent * 2)
+        .indent(this.options.indent ? this.indent * 2 : this.indent)
         .maxColWidth(150)
         .toString() +
       "\n";
@@ -341,8 +347,8 @@ export class HelpGenerator {
 
   private label(label: string) {
     return "\n" +
-      " ".repeat(this.indent) + bold(`${label}:`) +
-      "\n\n";
+      " ".repeat(this.options.indent ? this.indent : 0) + bold(`${label}:`) +
+      "\n" + (this.options.compact ? "" : "\n");
   }
 }
 

--- a/command/test/command/help_test.ts
+++ b/command/test/command/help_test.ts
@@ -161,3 +161,67 @@ Deno.test("[command] help - should ignore required options for help option", asy
 
   assertEquals(ctx.options, { help: true });
 });
+
+Deno.test("[command] help - should disable indentation", () => {
+  const cmd = new Command()
+    .throwErrors()
+    .help({ indent: false, colors: false })
+    .command("foo", "foo...")
+    .command("bar", "bar...");
+
+  assertEquals(
+    `
+Usage: COMMAND
+
+Options:
+
+  -h, --help  - Show this help.  
+
+Commands:
+
+  foo  - foo...
+  bar  - bar...
+`,
+    cmd.getHelp(),
+  );
+});
+
+Deno.test("[command] help - should enable compact mode", () => {
+  const cmd = new Command()
+    .throwErrors()
+    .help({ compact: true, colors: false })
+    .command("foo", "foo...")
+    .command("bar", "bar...");
+
+  assertEquals(
+    `Usage: COMMAND
+
+Options:
+  -h, --help  - Show this help.  
+
+Commands:
+  foo  - foo...
+  bar  - bar...`,
+    cmd.getHelp(),
+  );
+});
+
+Deno.test("[command] help - should enable compact mode and indentation", () => {
+  const cmd = new Command()
+    .throwErrors()
+    .help({ compact: true, indent: true, colors: false })
+    .command("foo", "foo...")
+    .command("bar", "bar...");
+
+  assertEquals(
+    `  Usage: COMMAND
+
+  Options:
+    -h, --help  - Show this help.  
+
+  Commands:
+    foo  - foo...
+    bar  - bar...`,
+    cmd.getHelp(),
+  );
+});


### PR DESCRIPTION
close #284