### PR TITLE
refactor(command): set default value for ignore and only in snapshotTest method

### DIFF
--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -110,8 +110,8 @@ function registerTest(options: SnapshotTestOptions) {
 
   Deno.test({
     name: options.name,
-    ignore: options.ignore,
-    only: options.only,
+    ignore: options.ignore ?? false,
+    only: options.only ?? false,
     async fn(ctx) {
       const steps = Object.entries(options.steps ?? {});
       if (steps.length) {


### PR DESCRIPTION
workaround for deno bug https://github.com/denoland/deno/issues/18784