### PR TITLE
refactor(command): throw an error if the command name is missing when generating shell completions

### DIFF
--- a/command/_errors.ts
+++ b/command/_errors.ts
@@ -40,7 +40,9 @@ export class MissingCommandNameCompletionsError extends CommandError {
         bold('cmd.name("<comand-name>")')
       }' to set the name of the main command or use the '${
         bold("--name")
-      }' option from the '${bold("completions")}' command to set the cli name: '${
+      }' option from the '${
+        bold("completions")
+      }' command to set the cli name: '${
         bold(`<command> completions ${shell} --name <cli-name>`)
       }'.`,
     );

--- a/command/_errors.ts
+++ b/command/_errors.ts
@@ -1,6 +1,7 @@
 import { didYouMeanCommand } from "./_utils.ts";
 import type { Command } from "./command.ts";
 import { getFlag } from "../flags/_utils.ts";
+import { bold } from "./deps.ts";
 import { EnvVar } from "./types.ts";
 
 export class CommandError extends Error {
@@ -29,6 +30,24 @@ export class DuplicateOptionNameError extends CommandError {
   constructor(name: string) {
     super(`Option with name "${getFlag(name)}" already exists.`);
     Object.setPrototypeOf(this, DuplicateOptionNameError.prototype);
+  }
+}
+
+export class MissingCommandNameCompletionsError extends CommandError {
+  constructor(shell: string) {
+    super(
+      `Failed to generate shell completions. Missing main command name. Use '${
+        bold('cmd.name("<comand-name>")')
+      }' to set the name of the main command or use the '${
+        bold("--name")
+      }' option from the '${bold("completions")}' command to set the cli name: '${
+        bold(`<command> completions ${shell} --name <cli-name>`)
+      }'.`,
+    );
+    Object.setPrototypeOf(
+      this,
+      MissingCommandNameCompletionsError.prototype,
+    );
   }
 }
 

--- a/command/command.ts
+++ b/command/command.ts
@@ -97,8 +97,6 @@ export class Command<
   private types: Map<string, TypeDef> = new Map();
   private rawArgs: Array<string> = [];
   private literalArgs: Array<string> = [];
-  // @TODO: get script name: https://github.com/denoland/deno/pull/5034
-  // private name: string = location.pathname.split( '/' ).pop() as string;
   private _name = "COMMAND";
   private _parent?: TParentCommand;
   private _globalParent?: Command<any>;
@@ -621,7 +619,7 @@ export class Command<
    **** SUB HANDLER ************************************************************
    *****************************************************************************/
 
-  /** Set command name. */
+  /** Set command name. Used in auto generated help and shell completions */
   public name(name: string): this {
     this.cmd._name = name;
     return this;

--- a/command/completions/_bash_completions_generator.ts
+++ b/command/completions/_bash_completions_generator.ts
@@ -1,3 +1,4 @@
+import { MissingCommandNameCompletionsError } from "../_errors.ts";
 import type { Command } from "../command.ts";
 import type { Argument } from "../types.ts";
 import { FileType } from "../types/file.ts";
@@ -6,6 +7,9 @@ import { FileType } from "../types/file.ts";
 export class BashCompletionsGenerator {
   /** Generates bash completions script for given command. */
   public static generate(name: string, cmd: Command) {
+    if (!name || name === "COMMAND") {
+      throw new MissingCommandNameCompletionsError("bash");
+    }
     return new BashCompletionsGenerator(name, cmd).generate();
   }
 

--- a/command/completions/_fish_completions_generator.ts
+++ b/command/completions/_fish_completions_generator.ts
@@ -1,3 +1,4 @@
+import { MissingCommandNameCompletionsError } from "../_errors.ts";
 import { getDescription } from "../_utils.ts";
 import type { Command } from "../command.ts";
 import type { Argument, Option } from "../types.ts";
@@ -17,6 +18,9 @@ interface CompleteOptions {
 export class FishCompletionsGenerator {
   /** Generates fish completions script for given command. */
   public static generate(name: string, cmd: Command) {
+    if (!name || name === "COMMAND") {
+      throw new MissingCommandNameCompletionsError("fish");
+    }
     return new FishCompletionsGenerator(name, cmd).generate();
   }
 

--- a/command/completions/_zsh_completions_generator.ts
+++ b/command/completions/_zsh_completions_generator.ts
@@ -1,3 +1,4 @@
+import { MissingCommandNameCompletionsError } from "../_errors.ts";
 import { getDescription } from "../_utils.ts";
 import type { Command } from "../command.ts";
 import type { Argument, Option, TypeDef } from "../types.ts";
@@ -16,6 +17,9 @@ export class ZshCompletionsGenerator {
 
   /** Generates zsh completions script for given command. */
   public static generate(name: string, cmd: Command) {
+    if (!name || name === "COMMAND") {
+      throw new MissingCommandNameCompletionsError("zsh");
+    }
     return new ZshCompletionsGenerator(name, cmd).generate();
   }
 


### PR DESCRIPTION
close #586