### PR TITLE
refactor(command): use exit code `2` as default for validation errors

### DIFF
--- a/command/_errors.ts
+++ b/command/_errors.ts
@@ -22,7 +22,7 @@ export class ValidationError extends CommandError {
   constructor(message: string, { exitCode }: ValidationErrorOptions = {}) {
     super(message);
     Object.setPrototypeOf(this, ValidationError.prototype);
-    this.exitCode = exitCode ?? 1;
+    this.exitCode = exitCode ?? 2;
   }
 }
 

--- a/examples/command/options.ts
+++ b/examples/command/options.ts
@@ -5,8 +5,8 @@ import { Command } from "../../command/command.ts";
 const { options } = await new Command()
   .option("-s, --silent", "disable output.")
   .option("-d, --debug [level]", "output extra debugging.")
-  .option("-p, --port <port>", "the port number.")
-  .option("-H, --host [hostname]", "the host name.", { default: "localhost" })
+  .option("-p, --port <port:number>", "the port number.")
+  .option("-H, --host <hostname>", "the host name.", { default: "localhost" })
   .parse(Deno.args);
 
 console.log("server running at %s:%s", options.host, options.port);


### PR DESCRIPTION
#590