### PR TITLE
feat(prompt): allow any type as value for select and checkbox prompt

### DIFF
--- a/prompt/_generic_input.ts
+++ b/prompt/_generic_input.ts
@@ -26,7 +26,7 @@ export interface GenericInputKeys extends GenericPromptKeys {
   moveCursorLeft?: string[];
   /** Cursor right keymap. Default is `["right"]`. */
   moveCursorRight?: string[];
-  /** Delete cursor right keymap. Default is `["backspace"]`. */
+  /** Delete cursor left keymap. Default is `["backspace"]`. */
   deleteCharLeft?: string[];
   /** Delete cursor right keymap. Default is `["delete"]`. */
   deleteCharRight?: string[];
@@ -44,7 +44,7 @@ export abstract class GenericInput<
   protected inputValue = "";
   protected inputIndex = 0;
 
-  protected getDefaultSettings(
+  public getDefaultSettings(
     options: GenericInputPromptOptions<TValue, TRawValue>,
   ): GenericInputPromptSettings<TValue, TRawValue> {
     const settings = super.getDefaultSettings(options);

--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -241,7 +241,7 @@ export abstract class GenericList<
   ): Array<TOption | TGroup>;
 
   protected mapOption(
-    options: GenericListOptions<TValue, TReturnValue, TRawValue>,
+    _options: GenericListOptions<TValue, TReturnValue, TRawValue>,
     option: GenericListOption<TValue> | GenericListSeparatorOption,
   ): GenericListOptionSettings<TValue> {
     if (isOption(option)) {

--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -50,8 +50,6 @@ export interface GenericListOptions<TValue, TReturnValue, TRawValue>
   groupIcon?: string | boolean;
   /** Change opened group icon. Default is `📂`. */
   groupOpenIcon?: string | boolean;
-  /** Format the display value. */
-  format?: (value: TValue) => string;
 }
 
 /** Generic list prompt settings. */
@@ -75,7 +73,6 @@ export interface GenericListSettings<
   groupPointer: string;
   groupIcon: string | false;
   groupOpenIcon: string | false;
-  format?: (value: TValue) => string;
 }
 
 /** Generic list separator option options. */
@@ -251,7 +248,7 @@ export abstract class GenericList<
       return {
         value: option.value,
         name: typeof option.name === "undefined"
-          ? options.format?.(option.value) ?? String(option.value)
+          ? String(option.value)
           : option.name,
         disabled: "disabled" in option && option.disabled === true,
         indentLevel: 0,

--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -20,6 +20,7 @@ export interface GenericListOptions<TValue, TReturnValue, TRawValue>
       UnsupportedInputOptions
     > {
   options: Array<
+    | Extract<TValue, string | number>
     | Extract<WidenType<TValue>, string | number>
     | GenericListOption<TValue>
     | GenericListOptionGroup<TValue, GenericListOption<TValue>>
@@ -102,6 +103,7 @@ export interface GenericListOptionGroup<
   name: string;
   /** An array of child options. */
   options: Array<
+    | Extract<TValue, string | number>
     | Extract<WidenType<TValue>, string | number>
     | TOption
     | this
@@ -233,6 +235,7 @@ export abstract class GenericList<
   protected abstract mapOptions(
     promptOptions: GenericListOptions<TValue, TReturnValue, TRawValue>,
     options: Array<
+      | Extract<TValue, string | number>
       | Extract<WidenType<TValue>, string | number>
       | GenericListOption<TValue>
       | GenericListOptionGroup<TValue, GenericListOption<TValue>>

--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -5,6 +5,7 @@ import {
   GenericInputPromptOptions,
   GenericInputPromptSettings,
 } from "./_generic_input.ts";
+import { WidenType } from "./_utils.ts";
 import { bold, brightBlue, dim, stripColor, yellow } from "./deps.ts";
 import { Figures, getFiguresByKeys } from "./_figures.ts";
 import { distance } from "../_utils/distance.ts";
@@ -12,13 +13,17 @@ import { distance } from "../_utils/distance.ts";
 type UnsupportedInputOptions = "suggestions" | "list";
 
 /** Generic list prompt options. */
-export interface GenericListOptions<TValue, TRawValue> extends
-  Omit<
-    GenericInputPromptOptions<TValue, TRawValue>,
-    UnsupportedInputOptions
-  > {
+export interface GenericListOptions<TValue, TReturnValue, TRawValue>
+  extends
+    Omit<
+      GenericInputPromptOptions<TReturnValue, TRawValue>,
+      UnsupportedInputOptions
+    > {
   options: Array<
-    string | GenericListOption | GenericListOptionGroup<GenericListOption>
+    | Extract<WidenType<TValue>, string | number>
+    | GenericListOption<TValue>
+    | GenericListOptionGroup<TValue, GenericListOption<TValue>>
+    | GenericListSeparatorOption
   >;
   /** Keymap to assign key names to prompt actions. */
   keys?: GenericListKeys;
@@ -44,15 +49,18 @@ export interface GenericListOptions<TValue, TRawValue> extends
   groupIcon?: string | boolean;
   /** Change opened group icon. Default is `📂`. */
   groupOpenIcon?: string | boolean;
+  /** Format the display value. */
+  format?: (value: TValue) => string;
 }
 
 /** Generic list prompt settings. */
 export interface GenericListSettings<
   TValue,
+  TReturnValue,
   TRawValue,
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
-> extends GenericInputPromptSettings<TValue, TRawValue> {
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
+> extends GenericInputPromptSettings<TReturnValue, TRawValue> {
   options: Array<TOption | TGroup>;
   keys: GenericListKeys;
   listPointer: string;
@@ -66,12 +74,19 @@ export interface GenericListSettings<
   groupPointer: string;
   groupIcon: string | false;
   groupOpenIcon: string | false;
+  format?: (value: TValue) => string;
+}
+
+/** Generic list separator option options. */
+export interface GenericListSeparatorOption {
+  /** The separator label. */
+  name: string;
 }
 
 /** Generic list option options. */
-export interface GenericListOption {
+export interface GenericListOption<TValue> {
   /** The option value. */
-  value: string;
+  value: TValue;
   /** The option label. */
   name?: string;
   /** Disable option. Disabled options are displayed but cannot be selected. */
@@ -79,27 +94,36 @@ export interface GenericListOption {
 }
 
 /** Generic list option group options. */
-export interface GenericListOptionGroup<TOption extends GenericListOption> {
+export interface GenericListOptionGroup<
+  TValue,
+  TOption extends GenericListOption<TValue>,
+> {
   /** The option label. */
   name: string;
   /** An array of child options. */
-  options: Array<string | TOption | this>;
+  options: Array<
+    | Extract<WidenType<TValue>, string | number>
+    | TOption
+    | this
+    | GenericListSeparatorOption
+  >;
   /** Disable option. Disabled options are displayed but cannot be selected. */
   disabled?: boolean;
 }
 
 /** Generic list option settings. */
-export interface GenericListOptionSettings extends GenericListOption {
+export interface GenericListOptionSettings<TValue>
+  extends GenericListOption<TValue> {
   name: string;
-  value: string;
   disabled: boolean;
   indentLevel: number;
 }
 
 /** Generic list option group settings. */
 export interface GenericListOptionGroupSettings<
-  TOption extends GenericListOptionSettings,
-> extends GenericListOptionGroup<TOption> {
+  TValue,
+  TOption extends GenericListOptionSettings<TValue>,
+> extends GenericListOptionGroup<TValue, TOption> {
   disabled: boolean;
   indentLevel: number;
   options: Array<TOption | this>;
@@ -122,23 +146,26 @@ export interface GenericListKeys extends GenericInputKeys {
 }
 
 interface MatchedOption<
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
+  TValue,
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
 > {
   option: TOption | TGroup;
   distance: number;
-  children: Array<MatchedOption<TOption, TGroup>>;
+  children: Array<MatchedOption<TValue, TOption, TGroup>>;
 }
 
 /** Generic list prompt representation. */
 export abstract class GenericList<
   TValue,
+  TReturnValue,
   TRawValue,
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
-> extends GenericInput<TValue, TRawValue> {
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
+> extends GenericInput<TReturnValue, TRawValue> {
   protected abstract readonly settings: GenericListSettings<
     TValue,
+    TReturnValue,
     TRawValue,
     TOption,
     TGroup
@@ -157,17 +184,17 @@ export abstract class GenericList<
    *
    * @param label Separator label.
    */
-  public static separator(label = "------------"): GenericListOption {
-    return { value: label, disabled: true };
+  public static separator(label = "------------"): GenericListSeparatorOption {
+    return { name: label };
   }
 
-  protected getDefaultSettings(
+  public getDefaultSettings(
     {
       groupIcon = true,
       groupOpenIcon = groupIcon,
       ...options
-    }: GenericListOptions<TValue, TRawValue>,
-  ): GenericListSettings<TValue, TRawValue, TOption, TGroup> {
+    }: GenericListOptions<TValue, TReturnValue, TRawValue>,
+  ): GenericListSettings<TValue, TReturnValue, TRawValue, TOption, TGroup> {
     const settings = super.getDefaultSettings(options);
     return {
       ...settings,
@@ -204,29 +231,43 @@ export abstract class GenericList<
   }
 
   protected abstract mapOptions(
-    promptOptions: GenericListOptions<TValue, TRawValue>,
+    promptOptions: GenericListOptions<TValue, TReturnValue, TRawValue>,
     options: Array<
-      string | GenericListOption | GenericListOptionGroup<GenericListOption>
+      | Extract<WidenType<TValue>, string | number>
+      | GenericListOption<TValue>
+      | GenericListOptionGroup<TValue, GenericListOption<TValue>>
+      | GenericListSeparatorOption
     >,
   ): Array<TOption | TGroup>;
 
   protected mapOption(
-    _options: GenericListOptions<TValue, TRawValue>,
-    option: GenericListOption,
-  ): GenericListOptionSettings {
-    return {
-      value: option.value,
-      name: typeof option.name === "undefined" ? option.value : option.name,
-      disabled: !!option.disabled,
-      indentLevel: 0,
-    };
+    options: GenericListOptions<TValue, TReturnValue, TRawValue>,
+    option: GenericListOption<TValue> | GenericListSeparatorOption,
+  ): GenericListOptionSettings<TValue> {
+    if (isOption(option)) {
+      return {
+        value: option.value,
+        name: typeof option.name === "undefined"
+          ? options.format?.(option.value) ?? String(option.value)
+          : option.name,
+        disabled: "disabled" in option && option.disabled === true,
+        indentLevel: 0,
+      };
+    } else {
+      return {
+        value: null as TValue,
+        name: option.name,
+        disabled: true,
+        indentLevel: 0,
+      };
+    }
   }
 
   protected mapOptionGroup(
-    options: GenericListOptions<TValue, TRawValue>,
-    option: GenericListOptionGroup<GenericListOption>,
+    options: GenericListOptions<TValue, TReturnValue, TRawValue>,
+    option: GenericListOptionGroup<TValue, GenericListOption<TValue>>,
     recursive = true,
-  ): GenericListOptionGroupSettings<GenericListOptionSettings> {
+  ): GenericListOptionGroupSettings<TValue, GenericListOptionSettings<TValue>> {
     return {
       name: option.name,
       disabled: !!option.disabled,
@@ -240,7 +281,7 @@ export abstract class GenericList<
     let options: Array<TOption | TGroup> = this.getCurrentOptions().slice();
 
     if (input.length) {
-      const matches = matchOptions<TOption, TGroup>(
+      const matches = matchOptions<TValue, TOption, TGroup>(
         input,
         this.getCurrentOptions(),
       );
@@ -436,7 +477,7 @@ export abstract class GenericList<
     option: TOption | TGroup,
     isSelected?: boolean,
   ): string {
-    let label: string = option.name;
+    let label = option.name;
 
     if (this.isBackButton(option)) {
       label = this.getBreadCrumb();
@@ -474,7 +515,7 @@ export abstract class GenericList<
     );
   }
 
-  protected getListIndex(value?: string) {
+  protected getListIndex(value?: TValue) {
     return Math.max(
       0,
       typeof value === "undefined"
@@ -501,7 +542,7 @@ export abstract class GenericList<
    * @param value Value of the option.
    */
   protected getOptionByValue(
-    value: string,
+    value: TValue,
   ): TOption | undefined {
     const option = this.options.find((option) =>
       isOption(option) && option.value === value
@@ -691,30 +732,42 @@ export abstract class GenericList<
 }
 
 export function isOption<
-  TOption extends GenericListOption,
+  TValue,
+  TOption extends GenericListOption<TValue>,
 >(
-  option: TOption | GenericListOptionGroup<GenericListOption> | undefined,
+  option:
+    | TOption
+    | GenericListOptionGroup<TValue, GenericListOption<TValue>>
+    | GenericListSeparatorOption
+    | undefined,
 ): option is TOption {
   return !!option && typeof option === "object" && "value" in option;
 }
 
 export function isOptionGroup<
-  TGroup extends GenericListOptionGroup<GenericListOption>,
+  TValue,
+  TGroup extends GenericListOptionGroup<TValue, GenericListOption<TValue>>,
 >(
-  option: TGroup | GenericListOption | string | undefined,
+  option:
+    | TGroup
+    | TValue
+    | GenericListOption<TValue>
+    | GenericListSeparatorOption
+    | undefined,
 ): option is TGroup {
-  return typeof option === "object" && "options" in option &&
+  return option !== null && typeof option === "object" && "options" in option &&
     option.options.length > 0;
 }
 
 function matchOptions<
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
+  TValue,
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
 >(
   searchInput: string,
   options: Array<TOption | TGroup>,
-): Array<MatchedOption<TOption, TGroup>> {
-  const matched: Array<MatchedOption<TOption, TGroup>> = [];
+): Array<MatchedOption<TValue, TOption, TGroup>> {
+  const matched: Array<MatchedOption<TValue, TOption, TGroup>> = [];
 
   for (const option of options) {
     if (isOptionGroup(option)) {
@@ -743,16 +796,17 @@ function matchOptions<
   return matched.sort(sortByDistance);
 
   function sortByDistance(
-    a: MatchedOption<TOption, TGroup>,
-    b: MatchedOption<TOption, TGroup>,
+    a: MatchedOption<TValue, TOption, TGroup>,
+    b: MatchedOption<TValue, TOption, TGroup>,
   ): number {
     return a.distance - b.distance;
   }
 }
 
 function matchOption<
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
+  TValue,
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
 >(
   inputString: string,
   option: TOption | TGroup,
@@ -760,7 +814,7 @@ function matchOption<
   return matchInput(inputString, option.name) || (
     isOption(option) &&
     option.name !== option.value &&
-    matchInput(inputString, option.value)
+    matchInput(inputString, String(option.value))
   );
 }
 
@@ -771,10 +825,11 @@ function matchInput(inputString: string, value: string): boolean {
 }
 
 function flatMatchedOptions<
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
+  TValue,
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
 >(
-  matches: Array<MatchedOption<TOption, TGroup>>,
+  matches: Array<MatchedOption<TValue, TOption, TGroup>>,
   indentLevel = 0,
   result: Array<TOption | TGroup> = [],
 ): Array<TOption | TGroup> {
@@ -788,6 +843,6 @@ function flatMatchedOptions<
 }
 
 /** @deprecated Use `Array<string | GenericListOption>` instead. */
-export type GenericListValueOptions = Array<string | GenericListOption>;
+export type GenericListValueOptions = Array<string | GenericListOption<string>>;
 /** @deprecated Use `Array<GenericListOptionSettings>` instead. */
-export type GenericListValueSettings = Array<GenericListOptionSettings>;
+export type GenericListValueSettings = Array<GenericListOptionSettings<string>>;

--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -759,7 +759,7 @@ export function isOptionGroup<
     | undefined,
 ): option is TGroup {
   return option !== null && typeof option === "object" && "options" in option &&
-    option.options.length > 0;
+    Array.isArray(option.options);
 }
 
 function matchOptions<

--- a/prompt/_generic_prompt.ts
+++ b/prompt/_generic_prompt.ts
@@ -14,12 +14,7 @@ import {
 import { Figures } from "./_figures.ts";
 
 /** Static generic prompt interface. */
-export interface StaticGenericPrompt<
-  TValue,
-  TRawValue,
-  TOptions extends GenericPromptOptions<TValue, TRawValue> =
-    GenericPromptOptions<TValue, TRawValue>,
-> {
+export interface StaticGenericPrompt<TValue, TOptions> {
   /**
    * Inject prompt value. If called, the prompt doesn't prompt for an input and
    * returns immediately the injected value. Can be used for unit tests or pre
@@ -37,6 +32,17 @@ export interface StaticGenericPrompt<
   prompt(options: TOptions): Promise<TValue>;
 }
 
+export type InferPromptOptions<TPrompt extends GenericPrompt<any, any>> =
+  Parameters<
+    TPrompt["getDefaultSettings"]
+  >[0];
+
+export type InferPromptValue<TPrompt extends GenericPrompt<any, any>> = Awaited<
+  ReturnType<
+    TPrompt["prompt"]
+  >
+>;
+
 /** Generic prompt options. */
 export interface GenericPromptOptions<TValue, TRawValue> {
   /** The prompt message. */
@@ -47,7 +53,7 @@ export interface GenericPromptOptions<TValue, TRawValue> {
   hideDefault?: boolean;
   /** Validate prompt value. */
   validate?: (value: TRawValue) => ValidateResult;
-  /** Format the display value. */
+  /** Transform input value to output value. */
   transform?: (value: TRawValue) => TValue | undefined;
   /** Show a hint below the prompt. */
   hint?: string;
@@ -124,7 +130,7 @@ export abstract class GenericPrompt<
     GenericPrompt.injectedValue = value;
   }
 
-  protected getDefaultSettings(
+  public getDefaultSettings(
     options: GenericPromptOptions<TValue, TRawValue>,
   ): GenericPromptSettings<TValue, TRawValue> {
     return {

--- a/prompt/_generic_prompt.ts
+++ b/prompt/_generic_prompt.ts
@@ -32,11 +32,13 @@ export interface StaticGenericPrompt<TValue, TOptions> {
   prompt(options: TOptions): Promise<TValue>;
 }
 
+// deno-lint-ignore no-explicit-any
 export type InferPromptOptions<TPrompt extends GenericPrompt<any, any>> =
   Parameters<
     TPrompt["getDefaultSettings"]
   >[0];
 
+// deno-lint-ignore no-explicit-any
 export type InferPromptValue<TPrompt extends GenericPrompt<any, any>> = Awaited<
   ReturnType<
     TPrompt["prompt"]

--- a/prompt/_generic_suggestions.ts
+++ b/prompt/_generic_suggestions.ts
@@ -109,7 +109,7 @@ export abstract class GenericSuggestions<TValue, TRawValue>
   protected suggestions: Array<string | number> = [];
   #hasReadPermissions?: boolean;
 
-  protected getDefaultSettings(
+  public getDefaultSettings(
     options: GenericSuggestionsOptions<TValue, TRawValue>,
   ): GenericSuggestionsSettings<TValue, TRawValue> {
     const settings = super.getDefaultSettings(options);

--- a/prompt/_utils.ts
+++ b/prompt/_utils.ts
@@ -3,3 +3,8 @@
 export function parseNumber(value: any): number {
   return Number(value);
 }
+
+export type WidenType<T> = T extends string ? string
+  : T extends number ? number
+  : T extends boolean ? boolean
+  : T;

--- a/prompt/checkbox.ts
+++ b/prompt/checkbox.ts
@@ -438,9 +438,7 @@ export class Checkbox<TValue> extends GenericList<
    * @param value Output value.
    */
   protected format(value: Array<TValue>): string {
-    return value.map((val) =>
-      this.settings.format?.(val) ?? this.getOptionByValue(val)?.name ?? val
-    )
+    return value.map((val) => this.getOptionByValue(val)?.name ?? String(val))
       .join(", ");
   }
 }

--- a/prompt/checkbox.ts
+++ b/prompt/checkbox.ts
@@ -217,7 +217,7 @@ export class Checkbox<TValue> extends GenericList<
       typeof option === "string" || typeof option === "number"
         ? this.mapOption(
           promptOptions,
-          { value: option } as CheckboxOption<TValue>,
+          { value: option as TValue },
         )
         : isCheckboxOptionGroup(option)
         ? this.mapOptionGroup(promptOptions, option)

--- a/prompt/checkbox.ts
+++ b/prompt/checkbox.ts
@@ -24,6 +24,7 @@ export interface CheckboxOptions<TValue>
   keys?: CheckboxKeys;
   /** An array of child options. */
   options: Array<
+    | Extract<TValue, string | number>
     | Extract<WidenType<TValue>, string | number>
     | CheckboxOption<TValue>
     | CheckboxOptionGroup<TValue>
@@ -203,6 +204,7 @@ export class Checkbox<TValue> extends GenericList<
   protected mapOptions(
     promptOptions: CheckboxOptions<TValue>,
     options: Array<
+      | Extract<TValue, string | number>
       | Extract<WidenType<TValue>, string | number>
       | CheckboxOption<TValue>
       | CheckboxOptionGroup<TValue>

--- a/prompt/checkbox.ts
+++ b/prompt/checkbox.ts
@@ -1,4 +1,5 @@
 import type { KeyCode } from "../keycode/mod.ts";
+import { WidenType } from "./_utils.ts";
 import { brightBlue, dim, green, red } from "./deps.ts";
 import { Figures, getFiguresByKeys } from "./_figures.ts";
 import {
@@ -9,6 +10,7 @@ import {
   GenericListOptionGroupSettings,
   GenericListOptions,
   GenericListOptionSettings,
+  GenericListSeparatorOption,
   GenericListSettings,
   isOption,
   isOptionGroup,
@@ -16,12 +18,17 @@ import {
 import { GenericPrompt } from "./_generic_prompt.ts";
 
 /** Checkbox prompt options. */
-export interface CheckboxOptions
-  extends GenericListOptions<Array<string>, Array<string>> {
+export interface CheckboxOptions<TValue>
+  extends GenericListOptions<TValue, Array<TValue>, Array<TValue>> {
   /** Keymap to assign key names to prompt actions. */
   keys?: CheckboxKeys;
   /** An array of child options. */
-  options: Array<string | CheckboxOption | CheckboxOptionGroup>;
+  options: Array<
+    | Extract<WidenType<TValue>, string | number>
+    | CheckboxOption<TValue>
+    | CheckboxOptionGroup<TValue>
+    | GenericListSeparatorOption
+  >;
   /** If enabled, the user needs to press enter twice. Default is `true`. */
   confirmSubmit?: boolean;
   /** Change check icon. Default is `green(Figures.TICK)`. */
@@ -37,12 +44,13 @@ export interface CheckboxOptions
 }
 
 /** Checkbox prompt settings. */
-interface CheckboxSettings extends
+interface CheckboxSettings<TValue> extends
   GenericListSettings<
-    Array<string>,
-    Array<string>,
-    CheckboxOptionSettings,
-    CheckboxOptionGroupSettings
+    TValue,
+    Array<TValue>,
+    Array<TValue>,
+    CheckboxOptionSettings<TValue>,
+    CheckboxOptionGroupSettings<TValue>
   > {
   confirmSubmit: boolean;
   check: string;
@@ -54,7 +62,7 @@ interface CheckboxSettings extends
 }
 
 /** Checkbox option options. */
-export interface CheckboxOption extends GenericListOption {
+export interface CheckboxOption<TValue> extends GenericListOption<TValue> {
   /** Set checked status. */
   checked?: boolean;
   /** Change option icon. */
@@ -62,21 +70,23 @@ export interface CheckboxOption extends GenericListOption {
 }
 
 /** Checkbox option group options. */
-export interface CheckboxOptionGroup
-  extends GenericListOptionGroup<CheckboxOption> {
+export interface CheckboxOptionGroup<TValue>
+  extends GenericListOptionGroup<TValue, CheckboxOption<TValue>> {
   /** Change option icon. */
   icon?: boolean;
 }
 
 /** Checkbox option settings. */
-export interface CheckboxOptionSettings extends GenericListOptionSettings {
+export interface CheckboxOptionSettings<TValue>
+  extends GenericListOptionSettings<TValue> {
   checked: boolean;
   icon: boolean;
 }
 
 /** Checkbox option group settings. */
-export interface CheckboxOptionGroupSettings
-  extends GenericListOptionGroupSettings<CheckboxOptionSettings> {
+export interface CheckboxOptionGroupSettings<TValue>
+  extends
+    GenericListOptionGroupSettings<TValue, CheckboxOptionSettings<TValue>> {
   readonly checked: boolean;
   icon: boolean;
 }
@@ -116,15 +126,16 @@ export interface CheckboxKeys extends GenericListKeys {
  * });
  * ```
  */
-export class Checkbox extends GenericList<
-  Array<string>,
-  Array<string>,
-  CheckboxOptionSettings,
-  CheckboxOptionGroupSettings
+export class Checkbox<TValue> extends GenericList<
+  TValue,
+  Array<TValue>,
+  Array<TValue>,
+  CheckboxOptionSettings<TValue>,
+  CheckboxOptionGroupSettings<TValue>
 > {
-  protected readonly settings: CheckboxSettings;
+  protected readonly settings: CheckboxSettings<TValue>;
   protected options: Array<
-    CheckboxOptionSettings | CheckboxOptionGroupSettings
+    CheckboxOptionSettings<TValue> | CheckboxOptionGroupSettings<TValue>
   >;
   protected listIndex: number;
   protected listOffset: number;
@@ -135,8 +146,10 @@ export class Checkbox extends GenericList<
    *
    * @param options Checkbox options.
    */
-  public static prompt(options: CheckboxOptions): Promise<Array<string>> {
-    return new this(options).prompt();
+  public static prompt<TValue>(
+    options: CheckboxOptions<TValue>,
+  ): Promise<Array<WidenType<TValue>>> {
+    return new this(options).prompt() as Promise<Array<WidenType<TValue>>>;
   }
 
   /**
@@ -144,12 +157,6 @@ export class Checkbox extends GenericList<
    *
    * @param label Separator label.
    */
-  public static separator(label?: string): CheckboxOption {
-    return {
-      ...super.separator(label),
-      icon: false,
-    };
-  }
 
   /**
    * Inject prompt value. If called, the prompt doesn't prompt for an input and
@@ -158,11 +165,11 @@ export class Checkbox extends GenericList<
    *
    * @param value Input value.
    */
-  public static inject(value: Array<string>): void {
+  public static inject<TValue>(value: Array<TValue>): void {
     GenericPrompt.inject(value);
   }
 
-  constructor(options: CheckboxOptions) {
+  constructor(options: CheckboxOptions<TValue>) {
     super();
     this.settings = this.getDefaultSettings(options);
     this.options = this.settings.options.slice();
@@ -170,7 +177,9 @@ export class Checkbox extends GenericList<
     this.listOffset = this.getPageOffset(this.listIndex);
   }
 
-  protected getDefaultSettings(options: CheckboxOptions): CheckboxSettings {
+  public getDefaultSettings(
+    options: CheckboxOptions<TValue>,
+  ): CheckboxSettings<TValue> {
     const settings = super.getDefaultSettings(options);
     return {
       confirmSubmit: true,
@@ -190,42 +199,56 @@ export class Checkbox extends GenericList<
     };
   }
 
-  /**
-   * Map string option values to options and set option defaults.
-   *
-   * @param promptOptions Checkbox options.
-   */
+  /** Map string option values to options and set option defaults. */
   protected mapOptions(
-    promptOptions: CheckboxOptions,
-    options: Array<string | CheckboxOption | CheckboxOptionGroup>,
-  ): Array<CheckboxOptionSettings | CheckboxOptionGroupSettings> {
+    promptOptions: CheckboxOptions<TValue>,
+    options: Array<
+      | Extract<WidenType<TValue>, string | number>
+      | CheckboxOption<TValue>
+      | CheckboxOptionGroup<TValue>
+      | GenericListSeparatorOption
+    >,
+  ): Array<
+    CheckboxOptionSettings<TValue> | CheckboxOptionGroupSettings<TValue>
+  > {
     return options.map((option) =>
-      isOptionGroup(option)
+      typeof option === "string" || typeof option === "number"
+        ? this.mapOption(
+          promptOptions,
+          { value: option } as CheckboxOption<TValue>,
+        )
+        : isCheckboxOptionGroup(option)
         ? this.mapOptionGroup(promptOptions, option)
-        : typeof option === "string"
-        ? this.mapOption(promptOptions, { value: option })
         : this.mapOption(promptOptions, option)
     );
   }
 
   protected mapOption(
-    options: CheckboxOptions,
-    option: CheckboxOption,
-  ): CheckboxOptionSettings {
-    return {
-      ...super.mapOption(options, option),
-      checked: typeof option.checked === "undefined" && options.default &&
-          options.default.indexOf(option.value) !== -1
-        ? true
-        : !!option.checked,
-      icon: typeof option.icon === "undefined" ? true : option.icon,
-    };
+    options: CheckboxOptions<TValue>,
+    option: CheckboxOption<TValue> | GenericListSeparatorOption,
+  ): CheckboxOptionSettings<TValue> {
+    if (isOption(option)) {
+      return {
+        ...super.mapOption(options, option),
+        checked: typeof option.checked === "undefined" && options.default &&
+            options.default.indexOf(option.value) !== -1
+          ? true
+          : !!option.checked,
+        icon: typeof option.icon === "undefined" ? true : option.icon,
+      };
+    } else {
+      return {
+        ...super.mapOption(options, option),
+        checked: false,
+        icon: false,
+      };
+    }
   }
 
   protected mapOptionGroup(
-    promptOptions: CheckboxOptions,
-    option: CheckboxOptionGroup,
-  ): CheckboxOptionGroupSettings {
+    promptOptions: CheckboxOptions<TValue>,
+    option: CheckboxOptionGroup<TValue>,
+  ): CheckboxOptionGroupSettings<TValue> {
     const options = this.mapOptions(promptOptions, option.options);
     return {
       ...super.mapOptionGroup(promptOptions, option, false),
@@ -245,13 +268,17 @@ export class Checkbox extends GenericList<
   }
 
   protected getListItemIcon(
-    option: CheckboxOptionSettings | CheckboxOptionGroupSettings,
+    option:
+      | CheckboxOptionSettings<TValue>
+      | CheckboxOptionGroupSettings<TValue>,
   ): string {
     return this.getCheckboxIcon(option) + super.getListItemIcon(option);
   }
 
   private getCheckboxIcon(
-    option: CheckboxOptionSettings | CheckboxOptionGroupSettings,
+    option:
+      | CheckboxOptionSettings<TValue>
+      | CheckboxOptionGroupSettings<TValue>,
   ): string {
     if (!option.icon) {
       return "";
@@ -266,8 +293,12 @@ export class Checkbox extends GenericList<
   }
 
   /** Get value of checked options. */
-  protected getValue(): Array<string> {
-    return flatOptions<CheckboxOptionSettings, CheckboxOptionGroupSettings>(
+  protected getValue(): Array<TValue> {
+    return flatOptions<
+      TValue,
+      CheckboxOptionSettings<TValue>,
+      CheckboxOptionGroupSettings<TValue>
+    >(
       this.settings.options,
     )
       .filter((option) => option.checked)
@@ -344,7 +375,9 @@ export class Checkbox extends GenericList<
   }
 
   private checkOption(
-    option: CheckboxOptionSettings | CheckboxOptionGroupSettings,
+    option:
+      | CheckboxOptionSettings<TValue>
+      | CheckboxOptionGroupSettings<TValue>,
     checked: boolean,
   ) {
     if (isOption(option)) {
@@ -361,18 +394,18 @@ export class Checkbox extends GenericList<
    * @param value User input value.
    * @return True on success, false or error message on error.
    */
-  protected validate(value: Array<string>): boolean | string {
+  protected validate(value: Array<TValue>): boolean | string {
     const options = flatOptions<
-      CheckboxOptionSettings,
-      CheckboxOptionGroupSettings
+      TValue,
+      CheckboxOptionSettings<TValue>,
+      CheckboxOptionGroupSettings<TValue>
     >(this.settings.options);
+
     const isValidValue = Array.isArray(value) &&
       value.every((val) =>
-        typeof val === "string" &&
-        val.length > 0 &&
-        options.findIndex((option: CheckboxOptionSettings) =>
-            option.value === val
-          ) !== -1
+        options.findIndex((option: CheckboxOptionSettings<TValue>) =>
+          option.value === val
+        ) !== -1
       );
 
     if (!isValidValue) {
@@ -394,30 +427,36 @@ export class Checkbox extends GenericList<
    * @param value Input value.
    * @return Output value.
    */
-  protected transform(value: Array<string>): Array<string> {
-    return value.map((val) => val.trim());
+  protected transform(value: Array<TValue>): Array<TValue> {
+    return value;
   }
 
   /**
    * Format output value.
    * @param value Output value.
    */
-  protected format(value: Array<string>): string {
-    return value.map((val) => this.getOptionByValue(val)?.name ?? val)
+  protected format(value: Array<TValue>): string {
+    return value.map((val) =>
+      this.settings.format?.(val) ?? this.getOptionByValue(val)?.name ?? val
+    )
       .join(", ");
   }
 }
 
-function areSomeChecked(
-  options: Array<CheckboxOptionSettings | CheckboxOptionGroupSettings>,
+function areSomeChecked<TValue>(
+  options: Array<
+    CheckboxOptionSettings<TValue> | CheckboxOptionGroupSettings<TValue>
+  >,
 ): boolean {
   return options.some((option) =>
     isOptionGroup(option) ? areSomeChecked(option.options) : option.checked
   );
 }
 
-function areAllChecked(
-  options: Array<CheckboxOptionSettings | CheckboxOptionGroupSettings>,
+function areAllChecked<TValue>(
+  options: Array<
+    CheckboxOptionSettings<TValue> | CheckboxOptionGroupSettings<TValue>
+  >,
 ): boolean {
   return options.every((option) =>
     isOptionGroup(option) ? areAllChecked(option.options) : option.checked
@@ -425,8 +464,9 @@ function areAllChecked(
 }
 
 function flatOptions<
-  TOption extends GenericListOptionSettings,
-  TGroup extends GenericListOptionGroupSettings<TOption>,
+  TValue,
+  TOption extends GenericListOptionSettings<TValue>,
+  TGroup extends GenericListOptionGroupSettings<TValue, TOption>,
 >(
   options: Array<TOption | TGroup>,
 ): Array<TOption> {
@@ -450,16 +490,24 @@ function flatOptions<
     return opts;
   }
 }
+
+export function isCheckboxOptionGroup(
+  option: unknown,
+  // deno-lint-ignore no-explicit-any
+): option is CheckboxOptionGroup<any> {
+  return isOptionGroup(option);
+}
+
 /**
  * Checkbox options type.
  * @deprecated Use `Array<string | CheckboxOption>` instead.
  */
-export type CheckboxValueOptions = Array<string | CheckboxOption>;
+export type CheckboxValueOptions = Array<string | CheckboxOption<string>>;
 
 /**
  * Checkbox option settings type.
  * @deprecated Use `Array<CheckboxOptionSettings | CheckboxOptionGroupSettings>` instead.
  */
 export type CheckboxValueSettings = Array<
-  CheckboxOptionSettings | CheckboxOptionGroupSettings
+  CheckboxOptionSettings<string> | CheckboxOptionGroupSettings<string>
 >;

--- a/prompt/confirm.ts
+++ b/prompt/confirm.ts
@@ -73,7 +73,7 @@ export class Confirm extends GenericSuggestions<boolean, string> {
     this.settings = this.getDefaultSettings(options);
   }
 
-  protected getDefaultSettings(options: ConfirmOptions): ConfirmSettings {
+  public getDefaultSettings(options: ConfirmOptions): ConfirmSettings {
     return {
       ...super.getDefaultSettings(options),
       active: options.active || "Yes",

--- a/prompt/input.ts
+++ b/prompt/input.ts
@@ -64,7 +64,7 @@ export class Input extends GenericSuggestions<string, string> {
     this.settings = this.getDefaultSettings(options);
   }
 
-  protected getDefaultSettings(options: InputOptions): InputSettings {
+  public getDefaultSettings(options: InputOptions): InputSettings {
     return {
       ...super.getDefaultSettings(options),
       minLength: options.minLength ?? 0,

--- a/prompt/list.ts
+++ b/prompt/list.ts
@@ -73,7 +73,7 @@ export class List extends GenericSuggestions<string[], string> {
     this.settings = this.getDefaultSettings(options);
   }
 
-  protected getDefaultSettings(options: ListOptions): ListSettings {
+  public getDefaultSettings(options: ListOptions): ListSettings {
     return {
       ...super.getDefaultSettings(options),
       separator: options.separator ?? ",",

--- a/prompt/number.ts
+++ b/prompt/number.ts
@@ -78,7 +78,7 @@ export class Number extends GenericSuggestions<number, string> {
     this.settings = this.getDefaultSettings(options);
   }
 
-  protected getDefaultSettings(options: NumberOptions): NumberSettings {
+  public getDefaultSettings(options: NumberOptions): NumberSettings {
     const settings = super.getDefaultSettings(options);
     return {
       ...settings,

--- a/prompt/prompt.ts
+++ b/prompt/prompt.ts
@@ -4,8 +4,12 @@ import { Tty, tty } from "../ansi/tty.ts";
 import {
   GenericPrompt,
   GenericPromptOptions,
+  InferPromptOptions,
+  InferPromptValue,
   StaticGenericPrompt,
 } from "./_generic_prompt.ts";
+import type { Select, SelectOptions } from "./select.ts";
+import type { Checkbox, CheckboxOptions } from "./checkbox.ts";
 
 /**
  * Prompt options for the `prompt()` method.
@@ -24,21 +28,40 @@ import {
  */
 export type PromptOptions<
   TName extends string,
-  TStaticPrompt extends StaticGenericPrompt<any, any>,
+  TPrompt extends GenericPrompt<any, any> | StaticGenericPrompt<any, any>,
   TResult extends
-    & PromptResult<TName, TStaticPrompt>
+    & PromptResult<TName, TPrompt>
     & Record<string, unknown> = PromptResult<
       TName,
-      TStaticPrompt
+      TPrompt
     >,
-> = Id<TResult & PromptResult<TName, TStaticPrompt>> extends infer Result ?
+> = Id<TResult & PromptResult<TName, TPrompt>> extends infer Result ?
     & {
       name: TName;
-      type: TStaticPrompt;
       before?: PromptMiddleware<Result>;
       after?: PromptMiddleware<Result>;
     }
-    & Parameters<TStaticPrompt["prompt"]>[0]
+    & (TPrompt extends GenericPrompt<any, any> ? (
+        & InferPromptOptions<TPrompt>
+        & {
+          type: StaticGenericPrompt<
+            InferPromptValue<TPrompt>,
+            InferPromptOptions<TPrompt>
+          >;
+        }
+      )
+      : TPrompt extends typeof Checkbox<infer Value> ? (
+          & CheckboxOptions<unknown extends Value ? string : Value>
+          & { type: TPrompt }
+        )
+      : TPrompt extends typeof Select<infer Value> ? (
+          & SelectOptions<unknown extends Value ? string : Value>
+          & { type: TPrompt }
+        )
+      : (
+        & Parameters<TPrompt["prompt"]>[0]
+        & { type: TPrompt }
+      ))
   : never;
 
 /**
@@ -141,10 +164,19 @@ export type Next<TName extends keyof any> = (
 /** Single prompt result. */
 type PromptResult<
   TName extends string,
-  TStaticPrompt extends StaticGenericPrompt<any, any> | void,
+  TPrompt extends
+    | GenericPrompt<any, any>
+    | StaticGenericPrompt<any, any>
+    | void,
 > = string extends TName ? {}
-  : TStaticPrompt extends StaticGenericPrompt<any, any> ? {
-      [Key in TName]?: Awaited<ReturnType<TStaticPrompt["prompt"]>>;
+  : TPrompt extends typeof Checkbox<infer U> ? {
+      [Key in TName]?: Array<unknown extends U ? string : U>;
+    }
+  : TPrompt extends typeof Select<infer U> ? {
+      [Key in TName]?: unknown extends U ? string : U;
+    }
+  : TPrompt extends GenericPrompt<any, any> | StaticGenericPrompt<any, any> ? {
+      [Key in TName]?: Awaited<ReturnType<TPrompt["prompt"]>>;
     }
   : {};
 
@@ -275,30 +307,30 @@ export function prompt<
   TOptions21 extends GenericPromptOptions<any, any>,
   TOptions22 extends GenericPromptOptions<any, any>,
   TOptions23 extends GenericPromptOptions<any, any>,
-  TStaticPrompt0 extends StaticGenericPrompt<any, any, TOptions0>,
-  TStaticPrompt1 extends StaticGenericPrompt<any, any, TOptions1>,
-  TStaticPrompt2 extends StaticGenericPrompt<any, any, TOptions2>,
-  TStaticPrompt3 extends StaticGenericPrompt<any, any, TOptions3>,
-  TStaticPrompt4 extends StaticGenericPrompt<any, any, TOptions4>,
-  TStaticPrompt5 extends StaticGenericPrompt<any, any, TOptions5>,
-  TStaticPrompt6 extends StaticGenericPrompt<any, any, TOptions6>,
-  TStaticPrompt7 extends StaticGenericPrompt<any, any, TOptions7>,
-  TStaticPrompt8 extends StaticGenericPrompt<any, any, TOptions8>,
-  TStaticPrompt9 extends StaticGenericPrompt<any, any, TOptions9>,
-  TStaticPrompt10 extends StaticGenericPrompt<any, any, TOptions10>,
-  TStaticPrompt11 extends StaticGenericPrompt<any, any, TOptions11>,
-  TStaticPrompt12 extends StaticGenericPrompt<any, any, TOptions12>,
-  TStaticPrompt13 extends StaticGenericPrompt<any, any, TOptions13>,
-  TStaticPrompt14 extends StaticGenericPrompt<any, any, TOptions14>,
-  TStaticPrompt15 extends StaticGenericPrompt<any, any, TOptions15>,
-  TStaticPrompt16 extends StaticGenericPrompt<any, any, TOptions16>,
-  TStaticPrompt17 extends StaticGenericPrompt<any, any, TOptions17>,
-  TStaticPrompt18 extends StaticGenericPrompt<any, any, TOptions18>,
-  TStaticPrompt19 extends StaticGenericPrompt<any, any, TOptions19>,
-  TStaticPrompt20 extends StaticGenericPrompt<any, any, TOptions20>,
-  TStaticPrompt21 extends StaticGenericPrompt<any, any, TOptions21>,
-  TStaticPrompt22 extends StaticGenericPrompt<any, any, TOptions22>,
-  TStaticPrompt23 extends StaticGenericPrompt<any, any, TOptions23>,
+  TStaticPrompt0 extends StaticGenericPrompt<any, TOptions0>,
+  TStaticPrompt1 extends StaticGenericPrompt<any, TOptions1>,
+  TStaticPrompt2 extends StaticGenericPrompt<any, TOptions2>,
+  TStaticPrompt3 extends StaticGenericPrompt<any, TOptions3>,
+  TStaticPrompt4 extends StaticGenericPrompt<any, TOptions4>,
+  TStaticPrompt5 extends StaticGenericPrompt<any, TOptions5>,
+  TStaticPrompt6 extends StaticGenericPrompt<any, TOptions6>,
+  TStaticPrompt7 extends StaticGenericPrompt<any, TOptions7>,
+  TStaticPrompt8 extends StaticGenericPrompt<any, TOptions8>,
+  TStaticPrompt9 extends StaticGenericPrompt<any, TOptions9>,
+  TStaticPrompt10 extends StaticGenericPrompt<any, TOptions10>,
+  TStaticPrompt11 extends StaticGenericPrompt<any, TOptions11>,
+  TStaticPrompt12 extends StaticGenericPrompt<any, TOptions12>,
+  TStaticPrompt13 extends StaticGenericPrompt<any, TOptions13>,
+  TStaticPrompt14 extends StaticGenericPrompt<any, TOptions14>,
+  TStaticPrompt15 extends StaticGenericPrompt<any, TOptions15>,
+  TStaticPrompt16 extends StaticGenericPrompt<any, TOptions16>,
+  TStaticPrompt17 extends StaticGenericPrompt<any, TOptions17>,
+  TStaticPrompt18 extends StaticGenericPrompt<any, TOptions18>,
+  TStaticPrompt19 extends StaticGenericPrompt<any, TOptions19>,
+  TStaticPrompt20 extends StaticGenericPrompt<any, TOptions20>,
+  TStaticPrompt21 extends StaticGenericPrompt<any, TOptions21>,
+  TStaticPrompt22 extends StaticGenericPrompt<any, TOptions22>,
+  TStaticPrompt23 extends StaticGenericPrompt<any, TOptions23>,
   TResult = Id<
     & PromptResult<TName0, TStaticPrompt0>
     & PromptResult<TName1, TStaticPrompt1>
@@ -452,7 +484,7 @@ export function prompt<
 ): Promise<TResult> {
   return new PromptList(
     prompts as Array<
-      PromptOptions<string, StaticGenericPrompt<unknown, unknown>>
+      PromptOptions<string, GenericPrompt<unknown, unknown>>
     >,
     options,
   ).run(options?.initial) as Promise<TResult>;
@@ -467,14 +499,14 @@ class PromptList {
 
   private get prompt(): PromptOptions<
     string,
-    StaticGenericPrompt<unknown, unknown>
+    GenericPrompt<unknown, unknown>
   > {
     return this.prompts[this.index];
   }
 
   public constructor(
     private prompts: Array<
-      PromptOptions<string, StaticGenericPrompt<unknown, unknown>>
+      PromptOptions<string, GenericPrompt<unknown, unknown>>
     >,
     private options?: GlobalPromptOptions<any>,
   ) {

--- a/prompt/secret.ts
+++ b/prompt/secret.ts
@@ -72,7 +72,7 @@ export class Secret extends GenericInput<string, string> {
     this.settings = this.getDefaultSettings(options);
   }
 
-  protected getDefaultSettings(options: SecretOptions): SecretSettings {
+  public getDefaultSettings(options: SecretOptions): SecretSettings {
     return {
       ...super.getDefaultSettings(options),
       label: options.label ?? "Secret",

--- a/prompt/select.ts
+++ b/prompt/select.ts
@@ -1,3 +1,4 @@
+import { WidenType } from "./_utils.ts";
 import { brightBlue, underline } from "./deps.ts";
 import {
   GenericList,
@@ -15,36 +16,46 @@ import { GenericPrompt } from "./_generic_prompt.ts";
 import { getFiguresByKeys } from "./_figures.ts";
 
 /** Select prompt options. */
-export interface SelectOptions extends GenericListOptions<string, string> {
+export interface SelectOptions<TValue>
+  extends GenericListOptions<TValue, TValue, TValue> {
   /** Keymap to assign key names to prompt actions. */
   keys?: SelectKeys;
   /** An array of child options. */
-  options: Array<string | SelectOption | SelectOptionGroup>;
+  options: Array<
+    | Extract<WidenType<TValue>, string | number>
+    | SelectOption<TValue>
+    | SelectOptionGroup<TValue>
+  >;
 }
 
 /** Select prompt settings. */
-export interface SelectSettings extends
+export interface SelectSettings<TValue> extends
   GenericListSettings<
-    string,
-    string,
-    SelectOptionSettings,
-    SelectOptionGroupSettings
+    TValue,
+    TValue,
+    TValue,
+    SelectOptionSettings<TValue>,
+    SelectOptionGroupSettings<TValue>
   > {
   keys: SelectKeys;
 }
 
 /** Select option options. */
-export type SelectOption = GenericListOption;
+export type SelectOption<TValue> = GenericListOption<TValue>;
 
 /** Select option group options. */
-export type SelectOptionGroup = GenericListOptionGroup<GenericListOption>;
+export type SelectOptionGroup<TValue> = GenericListOptionGroup<
+  TValue,
+  GenericListOption<TValue>
+>;
 
 /** Select option settings. */
-export type SelectOptionSettings = GenericListOptionSettings;
+export type SelectOptionSettings<TValue> = GenericListOptionSettings<TValue>;
 
 /** Select option group settings. */
-export type SelectOptionGroupSettings = GenericListOptionGroupSettings<
-  SelectOptionSettings
+export type SelectOptionGroupSettings<TValue> = GenericListOptionGroupSettings<
+  TValue,
+  SelectOptionSettings<TValue>
 >;
 
 /** Select prompt keymap. */
@@ -79,20 +90,25 @@ export type SelectKeys = GenericListKeys;
  * });
  * ```
  */
-export class Select extends GenericList<
-  string,
-  string,
-  SelectOptionSettings,
-  SelectOptionGroupSettings
+export class Select<TValue> extends GenericList<
+  TValue,
+  TValue,
+  TValue,
+  SelectOptionSettings<TValue>,
+  SelectOptionGroupSettings<TValue>
 > {
-  protected readonly settings: SelectSettings;
-  protected options: Array<SelectOptionSettings | SelectOptionGroupSettings>;
+  protected readonly settings: SelectSettings<TValue>;
+  protected options: Array<
+    SelectOptionSettings<TValue> | SelectOptionGroupSettings<TValue>
+  >;
   protected listIndex: number;
   protected listOffset: number;
 
   /** Execute the prompt with provided options. */
-  public static prompt(options: SelectOptions): Promise<string> {
-    return new this(options).prompt();
+  public static prompt<TValue>(
+    options: SelectOptions<TValue>,
+  ): Promise<WidenType<TValue>> {
+    return new this(options).prompt() as Promise<WidenType<TValue>>;
   }
 
   /**
@@ -106,7 +122,7 @@ export class Select extends GenericList<
     GenericPrompt.inject(value);
   }
 
-  constructor(options: SelectOptions) {
+  constructor(options: SelectOptions<TValue>) {
     super();
     this.settings = this.getDefaultSettings(options);
     this.options = this.settings.options.slice();
@@ -114,26 +130,32 @@ export class Select extends GenericList<
     this.listOffset = this.getPageOffset(this.listIndex);
   }
 
-  protected getDefaultSettings(options: SelectOptions): SelectSettings {
+  public getDefaultSettings(
+    options: SelectOptions<TValue>,
+  ): SelectSettings<TValue> {
     return {
       ...super.getDefaultSettings(options),
       options: this.mapOptions(options, options.options),
     };
   }
 
-  /**
-   * Map string option values to options and set option defaults.
-   * @param promptOptions Select options.
-   */
+  /** Map string option values to options and set option defaults. */
   protected mapOptions(
-    promptOptions: SelectOptions,
-    options: Array<string | SelectOption | SelectOptionGroup>,
-  ): Array<SelectOptionSettings | SelectOptionGroupSettings> {
+    promptOptions: SelectOptions<TValue>,
+    options: Array<
+      | Extract<WidenType<TValue>, string | number>
+      | SelectOption<TValue>
+      | SelectOptionGroup<TValue>
+    >,
+  ): Array<SelectOptionSettings<TValue> | SelectOptionGroupSettings<TValue>> {
     return options.map((option) =>
-      isOptionGroup(option)
+      isSelectOptionGroup(option)
         ? this.mapOptionGroup(promptOptions, option)
-        : typeof option === "string"
-        ? this.mapOption(promptOptions, { value: option })
+        : typeof option === "string" || typeof option === "number"
+        ? this.mapOption(
+          promptOptions,
+          { value: option } as SelectOption<TValue>,
+        )
         : this.mapOption(promptOptions, option)
     );
   }
@@ -160,10 +182,10 @@ export class Select extends GenericList<
   }
 
   /** Get value of selected option. */
-  protected getValue(): string {
+  protected getValue(): TValue {
     const option = this.options[this.listIndex];
     assertIsOption(option);
-    return option?.value ?? this.settings.default;
+    return option.value;
   }
 
   /**
@@ -171,13 +193,10 @@ export class Select extends GenericList<
    * @param value User input value.
    * @return True on success, false or error message on error.
    */
-  protected validate(value: string): boolean | string {
-    return typeof value === "string" &&
-      value.length > 0 &&
-      this.options.findIndex((
-          option: SelectOptionSettings | SelectOptionGroupSettings,
-        ) => isOption(option) && option.value === value
-        ) !== -1;
+  protected validate(value: TValue): boolean | string {
+    return this.options.findIndex((
+      option: SelectOptionSettings<TValue> | SelectOptionGroupSettings<TValue>,
+    ) => isOption(option) && option.value === value) !== -1;
   }
 
   /**
@@ -185,27 +204,36 @@ export class Select extends GenericList<
    * @param value Input value.
    * @return Output value.
    */
-  protected transform(value: string): string {
-    return value.trim();
+  protected transform(value: TValue): TValue {
+    return value;
   }
 
   /**
    * Format output value.
    * @param value Output value.
    */
-  protected format(value: string): string {
-    return this.getOptionByValue(value)?.name ?? value;
+  protected format(value: TValue): string {
+    return this.settings.format?.(value) ??
+      this.getOptionByValue(value)?.name ?? String(value);
   }
 }
 
 function assertIsOption<
-  TOption extends GenericListOption,
+  TValue,
+  TOption extends GenericListOption<TValue>,
 >(
-  option: TOption | GenericListOptionGroup<GenericListOption>,
+  option: TOption | GenericListOptionGroup<TValue, GenericListOption<TValue>>,
 ): asserts option is TOption {
   if (!isOption(option)) {
     throw new Error("Expected an option but got an option group.");
   }
+}
+
+export function isSelectOptionGroup(
+  option: unknown,
+  // deno-lint-ignore no-explicit-any
+): option is SelectOptionGroup<any> {
+  return isOptionGroup(option);
 }
 
 /**
@@ -213,7 +241,7 @@ function assertIsOption<
  * @deprecated Use `Array<string | SelectOption | SelectOptionGroup>` instead.
  */
 export type SelectValueOptions = Array<
-  string | SelectOption | SelectOptionGroup
+  string | SelectOption<string> | SelectOptionGroup<string>
 >;
 
 /**
@@ -221,5 +249,5 @@ export type SelectValueOptions = Array<
  * @deprecated Use `Array<SelectOptionSettings | SelectOptionGroupSettings>` instead.
  */
 export type SelectValueSettings = Array<
-  SelectOptionSettings | SelectOptionGroupSettings
+  SelectOptionSettings<string> | SelectOptionGroupSettings<string>
 >;

--- a/prompt/select.ts
+++ b/prompt/select.ts
@@ -215,8 +215,7 @@ export class Select<TValue> extends GenericList<
    * @param value Output value.
    */
   protected format(value: TValue): string {
-    return this.settings.format?.(value) ??
-      this.getOptionByValue(value)?.name ?? String(value);
+    return this.getOptionByValue(value)?.name ?? String(value);
   }
 }
 

--- a/prompt/select.ts
+++ b/prompt/select.ts
@@ -156,7 +156,7 @@ export class Select<TValue> extends GenericList<
         : typeof option === "string" || typeof option === "number"
         ? this.mapOption(
           promptOptions,
-          { value: option } as SelectOption<TValue>,
+          { value: option as TValue },
         )
         : this.mapOption(promptOptions, option)
     );

--- a/prompt/select.ts
+++ b/prompt/select.ts
@@ -22,6 +22,7 @@ export interface SelectOptions<TValue>
   keys?: SelectKeys;
   /** An array of child options. */
   options: Array<
+    | Extract<TValue, string | number>
     | Extract<WidenType<TValue>, string | number>
     | SelectOption<TValue>
     | SelectOptionGroup<TValue>
@@ -143,6 +144,7 @@ export class Select<TValue> extends GenericList<
   protected mapOptions(
     promptOptions: SelectOptions<TValue>,
     options: Array<
+      | Extract<TValue, string | number>
       | Extract<WidenType<TValue>, string | number>
       | SelectOption<TValue>
       | SelectOptionGroup<TValue>

--- a/prompt/test/integration/__snapshots__/checkbox_value_test.ts.snap
+++ b/prompt/test/integration/__snapshots__/checkbox_value_test.ts.snap
@@ -1,0 +1,18 @@
+export const snapshot = {};
+
+snapshot[`[checkbox] should handle none primitive values 1`] = `
+stdout:
+"? Select an option
+❯ ✘ date 1
+  ✘ date 2\\x1b[2A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select an option
+  ✘ date 1
+❯ ✘ date 2\\x1b[2A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select an option
+  ✘ date 1
+❯ ✔ date 2\\x1b[2A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select an option › date 2
+\\x1b[?25h\\x1b[?25h"
+stderr:
+""
+`;

--- a/prompt/test/integration/__snapshots__/checkbox_value_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/checkbox_value_test.ts.windows.snap
@@ -1,0 +1,18 @@
+export const snapshot = {};
+
+snapshot[`[checkbox] should handle none primitive values 1`] = `
+stdout:
+"? Select an option
+❯ × date 1
+  × date 2\\x1b[2A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select an option
+  × date 1
+❯ × date 2\\x1b[2A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select an option
+  × date 1
+❯ √ date 2\\x1b[2A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select an option » date 2
+\\x1b[?25h\\x1b[?25h"
+stderr:
+""
+`;

--- a/prompt/test/integration/__snapshots__/prompt_test.ts.snap
+++ b/prompt/test/integration/__snapshots__/prompt_test.ts.snap
@@ -8,7 +8,8 @@ stdout:
   number: 43,
   confirm: true,
   toggle: true,
-  checkbox: [ "bar", "baz" ]
+  checkbox: [ "bar", "baz" ],
+  select: 2
 }
 '
 stderr:
@@ -54,5 +55,14 @@ stderr:
   ✔ Bar
 ❯ ✔ Baz\\x1b[3A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
 ? Select an option › Bar, Baz
+\\x1b[?25h\\x1b[?25h\\x1b[?25h? Select a value
+❯ 1
+  2
+  3\\x1b[3A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select a value
+  1
+❯ 2
+  3\\x1b[3A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select a value › 2
 \\x1b[?25h\\x1b[?25h\\x1b[?25h"
 `;

--- a/prompt/test/integration/__snapshots__/prompt_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/prompt_test.ts.windows.snap
@@ -8,7 +8,8 @@ stdout:
   number: 43,
   confirm: true,
   toggle: true,
-  checkbox: [ "bar", "baz" ]
+  checkbox: [ "bar", "baz" ],
+  select: 2
 }
 '
 stderr:
@@ -54,5 +55,14 @@ stderr:
   √ Bar
 ❯ √ Baz\\x1b[3A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
 ? Select an option » Bar, Baz
+\\x1b[?25h\\x1b[?25h\\x1b[?25h? Select a value
+❯ 1
+  2
+  3\\x1b[3A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select a value
+  1
+❯ 2
+  3\\x1b[3A\\x1b[0G\\x1b[?25l\\x1b[G\\x1b[0J
+? Select a value » 2
 \\x1b[?25h\\x1b[?25h\\x1b[?25h"
 `;

--- a/prompt/test/integration/checkbox_value_test.ts
+++ b/prompt/test/integration/checkbox_value_test.ts
@@ -1,0 +1,23 @@
+import { ansi } from "../../../ansi/ansi.ts";
+import { snapshotTest } from "../../../testing/snapshot.ts";
+import { Checkbox } from "../../checkbox.ts";
+
+await snapshotTest({
+  name: "[checkbox] should handle none primitive values",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: ansi
+    .cursorDown
+    .text(" ")
+    .text("\n")
+    .toArray(),
+  async fn() {
+    await Checkbox.prompt({
+      message: "Select an option",
+      options: [
+        { name: "date 1", value: new Date(1000) },
+        { name: "date 2", value: new Date(2000) },
+      ],
+    });
+  },
+});

--- a/prompt/test/integration/prompt_test.ts
+++ b/prompt/test/integration/prompt_test.ts
@@ -1,10 +1,11 @@
 import { ansi } from "../../../ansi/ansi.ts";
-import { assertType, IsExact } from "../../../dev_deps.ts";
+import { assertEquals, assertType, IsExact } from "../../../dev_deps.ts";
 import { Checkbox, CheckboxOptions } from "../../checkbox.ts";
 import { Confirm } from "../../confirm.ts";
 import { Input } from "../../input.ts";
 import { Number } from "../../number.ts";
 import { prompt, PromptMiddleware, PromptOptions } from "../../prompt.ts";
+import { Select } from "../../select.ts";
 import { Toggle } from "../../toggle.ts";
 import { snapshotTest } from "../../../testing/snapshot.ts";
 
@@ -38,6 +39,9 @@ await snapshotTest({
         .cursorDown
         .text(" ")
         .text("\n")
+        // select
+        .cursorDown
+        .text("\n")
         .toArray(),
     },
   },
@@ -61,32 +65,45 @@ await snapshotTest({
       },
     };
 
-    const result = await prompt([{
-      name: "input",
-      type: Input,
-      message: "Enter some text",
-      default: "default value",
-    }, {
-      name: "number",
-      type: Number,
-      message: "Enter a number",
-    }, {
-      name: "confirm",
-      type: Confirm,
-      message: "Please confirm",
-    }, {
-      name: "toggle",
-      type: Toggle,
-      message: "Please toggle",
-      hint: "some hint",
-      default: false,
-    }, checkboxOptions], {
+    const result = await prompt([
+      {
+        name: "input",
+        type: Input,
+        message: "Enter some text",
+        default: "default value",
+      },
+      {
+        name: "number",
+        type: Number,
+        message: "Enter a number",
+      },
+      {
+        name: "confirm",
+        type: Confirm,
+        message: "Please confirm",
+      },
+      {
+        name: "toggle",
+        type: Toggle,
+        message: "Please toggle",
+        hint: "some hint",
+        default: false,
+      },
+      checkboxOptions,
+      {
+        name: "select",
+        type: Select<number>,
+        message: "Select a value",
+        options: [1, 2, 3],
+      },
+    ], {
       reader: Deno.stdin,
       writer: Deno.stderr,
     });
 
     assertType<
       IsExact<typeof result, {
+        select?: number | undefined;
         checkbox?: string[] | undefined;
         input?: string | undefined;
         number?: number | undefined;
@@ -94,6 +111,15 @@ await snapshotTest({
         toggle?: boolean | undefined;
       }>
     >(true);
+
+    assertEquals(result, {
+      input: "foo",
+      number: 43,
+      confirm: true,
+      toggle: true,
+      checkbox: ["bar", "baz"],
+      select: 2,
+    });
 
     assertType<
       IsExact<
@@ -107,7 +133,7 @@ await snapshotTest({
           after?: PromptMiddleware<
             { checkbox?: Array<string>; input?: string }
           >;
-        } & CheckboxOptions
+        } & CheckboxOptions<string>
       >
     >(true);
 

--- a/prompt/toggle.ts
+++ b/prompt/toggle.ts
@@ -63,7 +63,7 @@ export class Toggle extends GenericPrompt<boolean, string> {
       : "";
   }
 
-  protected getDefaultSettings(options: ToggleOptions): ToggleSettings {
+  public getDefaultSettings(options: ToggleOptions): ToggleSettings {
     const settings = super.getDefaultSettings(options);
     return {
       ...settings,


### PR DESCRIPTION
close #562

```ts
const today = new Date();
const tomorrow = new Date();
tomorrow.setDate(today.getDate() + 1);

// Select prompt:
const date = await Select.prompt({
  message: "Select a date",
  options: [
    { name: "Today", value: today },
    { name: "Tomorrow", value: tomorrow },
  ],
});

console.log("Date:", date);

// With prompt method:
const result = await prompt([{
  name: "date",
  type: Select<Date>,
  message: "Select a date",
  options: [
    { name: "Today", value: today },
    { name: "Tomorrow", value: tomorrow },
  ],
}]);

console.log("Date:", result.date);
```