### PR TITLE
docs(command): fix markdown formatting for arguments (#677)

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -800,9 +800,9 @@ export class Command<
   }
 
   /**
-   * Set command arguments:
+   * Set command arguments.
    *
-   *   <requiredArg:string> [optionalArg: number] [...restArgs:string]
+   * Syntax: `<requiredArg:string> [optionalArg: number] [...restArgs:string]`
    */
   public arguments<
     TArguments extends TypedArguments<


### PR DESCRIPTION
Fixes #677.

Before:
![image](https://github.com/c4spar/deno-cliffy/assets/26078826/e7028fc5-2c42-4628-90f9-c11756f13c08)

After:
![image](https://github.com/c4spar/deno-cliffy/assets/26078826/6ecdfd19-0fca-4619-9e99-7da85f3329a4)
