### PR TITLE
feat: add support for `jsr` repository

### DIFF
--- a/ansi/ansi_escapes.ts
+++ b/ansi/ansi_escapes.ts
@@ -3,7 +3,7 @@ import { encodeBase64 } from "./deps.ts";
 /** Escape sequence: `\x1B` */
 const ESC = "\x1B";
 /** Control sequence intro: `\x1B[` */
-const CSI = `${ESC}[`;
+const CSI: `\x1B[` = `${ESC}[`;
 /** Operating system command: `\x1B]` */
 const OSC = `${ESC}]`;
 /** Link separator */
@@ -12,7 +12,7 @@ const SEP = ";";
 /** Ring audio bell: `\u0007` */
 export const bel = "\u0007";
 /** Get cursor position. */
-export const cursorPosition = `${CSI}6n`;
+export const cursorPosition: `\x1B[6n` = `${CSI}6n`;
 
 /**
  * Move cursor to x, y, counting from the top left corner.
@@ -98,15 +98,15 @@ export function cursorPrevLine(count = 1): string {
 }
 
 /** Move cursor to first column of current row. */
-export const cursorLeft = `${CSI}G`;
+export const cursorLeft: `\x1B[G` = `${CSI}G`;
 /** Hide cursor. */
-export const cursorHide = `${CSI}?25l`;
+export const cursorHide: `\x1B[?25l` = `${CSI}?25l`;
 /** Show cursor. */
-export const cursorShow = `${CSI}?25h`;
+export const cursorShow: `\x1B[?25h` = `${CSI}?25h`;
 /** Save cursor. */
-export const cursorSave = `${ESC}7`;
+export const cursorSave: `\x1B7` = `${ESC}7`;
 /** Restore cursor. */
-export const cursorRestore = `${ESC}8`;
+export const cursorRestore: `\x1B8` = `${ESC}8`;
 
 /**
  * Scroll window up by n lines.
@@ -125,7 +125,7 @@ export function scrollDown(count = 1): string {
 }
 
 /** Clear screen. */
-export const eraseScreen = `${CSI}2J`;
+export const eraseScreen: `\x1B[2J` = `${CSI}2J`;
 
 /**
  * Clear screen up by n lines.
@@ -144,11 +144,11 @@ export function eraseDown(count = 1): string {
 }
 
 /** Clear current line. */
-export const eraseLine = `${CSI}2K`;
+export const eraseLine: `\x1B[2K` = `${CSI}2K`;
 /** Clear to line end. */
-export const eraseLineEnd = `${CSI}0K`;
+export const eraseLineEnd: `\x1B[0K` = `${CSI}0K`;
 /** Clear to line start. */
-export const eraseLineStart = `${CSI}1K`;
+export const eraseLineStart: `\x1B[1K` = `${CSI}1K`;
 
 /**
  * Clear screen and move cursor by n lines up and move cursor to first column.
@@ -170,7 +170,7 @@ export const clearScreen = "\u001Bc";
  * Clear the whole terminal, including scrollback buffer.
  * (Not just the visible part of it).
  */
-export const clearTerminal = Deno.build.os === "windows"
+export const clearTerminal: string = Deno.build.os === "windows"
   ? `${eraseScreen}${CSI}0f`
   // 1. Erases the screen (Only done in case `2` is not supported)
   // 2. Erases the whole screen including scrollback buffer

--- a/ansi/colors.ts
+++ b/ansi/colors.ts
@@ -1,4 +1,4 @@
-import * as stdColors from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import * as stdColors from "@std/fmt/colors";
 
 type ExcludedColorMethods = "setColorEnabled" | "getColorEnabled";
 type PropertyNames = keyof typeof stdColors;

--- a/ansi/deps.ts
+++ b/ansi/deps.ts
@@ -1,5 +1,5 @@
-export { encodeBase64 } from "https://deno.land/std@0.216.0/encoding/base64.ts";
+export { encodeBase64 } from "@std/encoding/base64";
 export type {
   ReaderSync,
   WriterSync,
-} from "https://deno.land/std@0.216.0/io/types.ts";
+} from "@std/io/types";

--- a/command/command.ts
+++ b/command/command.ts
@@ -2294,7 +2294,7 @@ export class Command<
   }
 
   /** Check if command has arguments. */
-  public hasArguments() {
+  public hasArguments(): boolean {
     return !!this.argsDefinition;
   }
 
@@ -2317,7 +2317,7 @@ export class Command<
   }
 
   /** Get auto generated command usage. */
-  public getUsage() {
+  public getUsage(): string {
     return this._usage ??
       [this.getArgsDefinition(), this.getRequiredOptionsDefinition()]
         .join(" ")
@@ -2798,7 +2798,7 @@ export class Command<
   }
 
   /** Get completions. */
-  public getCompletions() {
+  public getCompletions(): Completion<any, any, any, any, any, any, any, any>[] {
     return this.getGlobalCompletions().concat(this.getBaseCompletions());
   }
 

--- a/command/deps.ts
+++ b/command/deps.ts
@@ -10,4 +10,4 @@ export {
   red,
   setColorEnabled,
   yellow,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+} from "@std/fmt/colors";

--- a/command/test/command/generic_types_test.ts
+++ b/command/test/command/generic_types_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   IsAny,
   IsExact,
-} from "https://deno.land/x/conditional_type_checks@1.0.6/mod.ts";
+} from "conditional_type_checks";
 
 // Not required to execute this code, only type check.
 (() => {

--- a/command/test/type/file_test.ts
+++ b/command/test/type/file_test.ts
@@ -1,7 +1,7 @@
 import {
   assert,
   IsExact,
-} from "https://deno.land/x/conditional_type_checks@1.0.6/mod.ts";
+} from "conditional_type_checks";
 import { assertEquals } from "../../../dev_deps.ts";
 import { Command } from "../../command.ts";
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -32,17 +32,17 @@
 		// "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
 	},
   "imports": {
-    "@std/assert": "jsr:@std/assert@0.216",
-    "@std/async": "jsr:@std/async@0.216",
-    "@std/console": "jsr:@std/console@0.216",
-    "@std/datetime": "jsr:@std/datetime@0.216",
-    "@std/encoding": "jsr:@std/encoding@0.216",
-    "@std/fmt": "jsr:@std/fmt@0.216",
-    "@std/fs": "jsr:@std/fs@0.216",
-    "@std/http": "jsr:@std/http@0.216",
-    "@std/io": "jsr:@std/io@0.216",
-    "@std/path": "jsr:@std/path@0.216",
-    "@std/testing": "jsr:@std/testing@0.216",
+    "@std/assert": "jsr:@std/assert@0.217",
+    "@std/async": "jsr:@std/async@0.217",
+    "@std/console": "jsr:@std/console@0.217",
+    "@std/datetime": "jsr:@std/datetime@0.217",
+    "@std/encoding": "jsr:@std/encoding@0.217",
+    "@std/fmt": "jsr:@std/fmt@0.217",
+    "@std/fs": "jsr:@std/fs@0.217",
+    "@std/http": "jsr:@std/http@0.217",
+    "@std/io": "jsr:@std/io@0.217",
+    "@std/path": "jsr:@std/path@0.217",
+    "@std/testing": "jsr:@std/testing@0.217",
     "conditional_type_checks": "npm:conditional-type-checks@1.0.6",
     "sinon": "npm:sinon@13.0.2"
   }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,5 +30,20 @@
 		"coverage:testing": "deno task test testing --coverage=./dist/coverage/testing/result && deno coverage --lcov ./dist/coverage/testing/result > ./dist/coverage/testing/cov.lcov",
 		"update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.5/cli.ts --ignore README.md CHANGELOG.md CONTRIBUTING.md"
 		// "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
-	}
+	},
+  "imports": {
+    "@std/assert": "jsr:@std/assert@0.216",
+    "@std/async": "jsr:@std/async@0.216",
+    "@std/console": "jsr:@std/console@0.216",
+    "@std/datetime": "jsr:@std/datetime@0.216",
+    "@std/encoding": "jsr:@std/encoding@0.216",
+    "@std/fmt": "jsr:@std/fmt@0.216",
+    "@std/fs": "jsr:@std/fs@0.216",
+    "@std/http": "jsr:@std/http@0.216",
+    "@std/io": "jsr:@std/io@0.216",
+    "@std/path": "jsr:@std/path@0.216",
+    "@std/testing": "jsr:@std/testing@0.216",
+    "conditional_type_checks": "npm:conditional-type-checks@1.0.6",
+    "sinon": "npm:sinon@13.0.2"
+  }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,22 +1,34 @@
 {
-  "lock": false,
-  "exclude": ["dist"],
-  "tasks": {
-    "lint": "deno lint && deno fmt --check",
-    "fmt": "deno fmt",
-    "test": "deno test --doc --allow-run=deno --allow-env --allow-read=./  --allow-write=./ --ignore=./CHANGELOG.md --parallel",
-    "check:examples": "deno check examples/**/*.ts",
-    "snapshot": "deno task test -- --update",
-    "coverage": "deno task test --coverage=./dist/coverage/all/result && deno coverage --lcov ./dist/coverage/all/result > ./dist/coverage/all/cov.lcov",
-    "coverage:ansi": "deno task test ansi --coverage=./dist/coverage/ansi/result && deno coverage --lcov ./dist/coverage/ansi/result > ./dist/coverage/ansi/cov.lcov",
-    "coverage:command": "deno task test command --coverage=./dist/coverage/command/result && deno coverage --lcov ./dist/coverage/command/result > ./dist/coverage/command/cov.lcov",
-    "coverage:flags": "deno task test flags --coverage=./dist/coverage/flags/result && deno coverage --lcov ./dist/coverage/flags/result > ./dist/coverage/flags/cov.lcov",
-    "coverage:keycode": "deno task test keycode --coverage=./dist/coverage/keycode/result && deno coverage --lcov ./dist/coverage/keycode/result > ./dist/coverage/keycode/cov.lcov",
-    "coverage:keypress": "deno task test keypress --coverage=./dist/coverage/keypress/result && deno coverage --lcov ./dist/coverage/keypress/result > ./dist/coverage/keypress/cov.lcov",
-    "coverage:prompt": "deno task test prompt --coverage=./dist/coverage/prompt/result && deno coverage --lcov ./dist/coverage/prompt/result > ./dist/coverage/prompt/cov.lcov",
-    "coverage:table": "deno task test table --coverage=./dist/coverage/table/result && deno coverage --lcov ./dist/coverage/table/result > ./dist/coverage/table/cov.lcov",
-    "coverage:testing": "deno task test testing --coverage=./dist/coverage/testing/result && deno coverage --lcov ./dist/coverage/testing/result > ./dist/coverage/testing/cov.lcov",
-    "update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.5/cli.ts --ignore README.md CHANGELOG.md CONTRIBUTING.md"
-    // "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
-  }
+	"name": "@c4spar/cliffy",
+	"version": "1.0.0-rc.3",
+	"exports": {
+		"ansi": "./ansi/mod.ts",
+		"command": "./command/mod.ts",
+		"flags": "./flags/mod.ts",
+		"keycode": "./keycode/mod.ts",
+		"keypress": "./keypress/mod.ts",
+		"prompt": "./prompt/mod.ts",
+		"table": "./table/mod.ts",
+		"testing": "./testing/mod.ts"
+	},
+	"lock": false,
+	"exclude": ["dist"],
+	"tasks": {
+		"lint": "deno lint && deno fmt --check",
+		"fmt": "deno fmt",
+		"test": "deno test --doc --allow-run=deno --allow-env --allow-read=./  --allow-write=./ --ignore=./CHANGELOG.md --parallel",
+		"check:examples": "deno check examples/**/*.ts",
+		"snapshot": "deno task test -- --update",
+		"coverage": "deno task test --coverage=./dist/coverage/all/result && deno coverage --lcov ./dist/coverage/all/result > ./dist/coverage/all/cov.lcov",
+		"coverage:ansi": "deno task test ansi --coverage=./dist/coverage/ansi/result && deno coverage --lcov ./dist/coverage/ansi/result > ./dist/coverage/ansi/cov.lcov",
+		"coverage:command": "deno task test command --coverage=./dist/coverage/command/result && deno coverage --lcov ./dist/coverage/command/result > ./dist/coverage/command/cov.lcov",
+		"coverage:flags": "deno task test flags --coverage=./dist/coverage/flags/result && deno coverage --lcov ./dist/coverage/flags/result > ./dist/coverage/flags/cov.lcov",
+		"coverage:keycode": "deno task test keycode --coverage=./dist/coverage/keycode/result && deno coverage --lcov ./dist/coverage/keycode/result > ./dist/coverage/keycode/cov.lcov",
+		"coverage:keypress": "deno task test keypress --coverage=./dist/coverage/keypress/result && deno coverage --lcov ./dist/coverage/keypress/result > ./dist/coverage/keypress/cov.lcov",
+		"coverage:prompt": "deno task test prompt --coverage=./dist/coverage/prompt/result && deno coverage --lcov ./dist/coverage/prompt/result > ./dist/coverage/prompt/cov.lcov",
+		"coverage:table": "deno task test table --coverage=./dist/coverage/table/result && deno coverage --lcov ./dist/coverage/table/result > ./dist/coverage/table/cov.lcov",
+		"coverage:testing": "deno task test testing --coverage=./dist/coverage/testing/result && deno coverage --lcov ./dist/coverage/testing/result > ./dist/coverage/testing/cov.lcov",
+		"update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.5/cli.ts --ignore README.md CHANGELOG.md CONTRIBUTING.md"
+		// "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
+	}
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,14 +2,14 @@
 	"name": "@c4spar/cliffy",
 	"version": "1.0.0-rc.3",
 	"exports": {
-		"ansi": "./ansi/mod.ts",
-		"command": "./command/mod.ts",
-		"flags": "./flags/mod.ts",
-		"keycode": "./keycode/mod.ts",
-		"keypress": "./keypress/mod.ts",
-		"prompt": "./prompt/mod.ts",
-		"table": "./table/mod.ts",
-		"testing": "./testing/mod.ts"
+		"./ansi": "./ansi/mod.ts",
+		"./command": "./command/mod.ts",
+		"./flags": "./flags/mod.ts",
+		"./keycode": "./keycode/mod.ts",
+		"./keypress": "./keypress/mod.ts",
+		"./prompt": "./prompt/mod.ts",
+		"./table": "./table/mod.ts",
+		"./testing": "./testing/mod.ts"
 	},
 	"lock": false,
 	"exclude": ["dist"],

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -6,28 +6,28 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.216.0/assert/mod.ts";
+} from "@std/assert";
 export {
   assertSpyCall,
   assertSpyCalls,
   spy,
-} from "https://deno.land/std@0.216.0/testing/mock.ts";
-export { assertSnapshot } from "https://deno.land/std@0.216.0/testing/snapshot.ts";
-export { describe, it } from "https://deno.land/std@0.216.0/testing/bdd.ts";
+} from "@std/testing/mock";
+export { assertSnapshot } from "@std/testing/snapshot";
+export { describe, it } from "@std/testing/bdd";
 export {
   assertType,
   type IsExact,
-} from "https://deno.land/std@0.216.0/testing/types.ts";
+} from "@std/testing/types";
 export {
   bold,
   red,
   stripColor,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
-export { dirname } from "https://deno.land/std@0.216.0/path/dirname.ts";
-export { expandGlob } from "https://deno.land/std@0.216.0/fs/expand_glob.ts";
-export type { WalkEntry } from "https://deno.land/std@0.216.0/fs/walk.ts";
-export { copy } from "https://deno.land/std@0.216.0/io/copy.ts";
-export { format } from "https://deno.land/std@0.216.0/datetime/format.ts";
+} from "@std/fmt/colors";
+export { dirname } from "@std/path/dirname";
+export { expandGlob } from "@std/fs/expand_glob";
+export type { WalkEntry } from "@std/fs/walk";
+export { copy } from "@std/io/copy";
+export { format } from "@std/datetime/format";
 
 /* 3rd party */
-export { default as sinon } from "https://cdn.skypack.dev/sinon@v13.0.2?dts";
+export { default as sinon } from "sinon";

--- a/examples/ansi.ts
+++ b/examples/ansi.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run
 
 import { colors, tty } from "../ansi/mod.ts";
-import { delay } from "https://deno.land/std@0.216.0/async/delay.ts";
+import { delay } from "@std/async/delay";
 
 const error = colors.bold.red;
 const warn = colors.bold.yellow;

--- a/examples/ansi/custom.ts
+++ b/examples/ansi/custom.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-net=deno.land
 
-import { rgb24 } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import { rgb24 } from "@std/fmt/colors";
 import { tty } from "../../ansi/tty.ts";
 
 const response = await fetch("https://deno.land/images/hashrock_simple.png");

--- a/examples/ansi/demo.ts
+++ b/examples/ansi/demo.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import * as stdColors from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import * as stdColors from "@std/fmt/colors";
 import * as ansiEscapes from "../../ansi/ansi_escapes.ts";
 
 const ansiEscapeNames1: Array<keyof typeof ansiEscapes> = [

--- a/examples/command.ts
+++ b/examples/command.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-net=localhost:8080,deno.land
 
 import { Command } from "../command/mod.ts";
-import { serve } from "https://deno.land/std@0.216.0/http/server.ts";
+import { serve } from "@std/http/server";
 
 await new Command()
   .name("reverse-proxy")

--- a/examples/command/examples.ts
+++ b/examples/command/examples.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { red } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import { red } from "@std/fmt/colors";
 import { Command } from "../../command/command.ts";
 
 await new Command()

--- a/examples/prompt/custom_prompts.ts
+++ b/examples/prompt/custom_prompts.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { BufReader } from "https://deno.land/std@0.216.0/io/buf_reader.ts";
+import { BufReader } from "@std/io/buf_reader";
 import { tty } from "../../ansi/tty.ts";
 import { Figures } from "../../prompt/_figures.ts";
 import { prompt } from "../../prompt/prompt.ts";

--- a/examples/prompt/prompt_demo.ts
+++ b/examples/prompt/prompt_demo.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { rgb24 } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import { rgb24 } from "@std/fmt/colors";
 import { tty } from "../../ansi/tty.ts";
 import { prompt } from "../../prompt/prompt.ts";
 import { Checkbox } from "../../prompt/checkbox.ts";

--- a/examples/table/random_table_demo.ts
+++ b/examples/table/random_table_demo.ts
@@ -11,7 +11,7 @@ import {
   strikethrough,
   underline,
   yellow,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+} from "@std/fmt/colors";
 import { tty } from "../../ansi/tty.ts";
 import { Cell, CellType } from "../../table/cell.ts";
 import { Table } from "../../table/table.ts";

--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -177,7 +177,7 @@ export abstract class GenericList<
   protected abstract listOffset: number;
   protected parentOptions: Array<TGroup> = [];
 
-  protected get selectedOption() {
+  protected get selectedOption(): TOption | TGroup | undefined {
     return this.options.at(this.listIndex);
   }
 
@@ -440,7 +440,7 @@ export abstract class GenericList<
     return line;
   }
 
-  protected getListItemIndent(option: TOption | TGroup) {
+  protected getListItemIndent(option: TOption | TGroup): string {
     const indentLevel = this.isSearching()
       ? option.indentLevel
       : this.hasParent() && !this.isBackButton(option)
@@ -450,7 +450,7 @@ export abstract class GenericList<
     return this.settings.indent + " ".repeat(indentLevel);
   }
 
-  protected getListItemPointer(option: TOption | TGroup, isSelected?: boolean) {
+  protected getListItemPointer(option: TOption | TGroup, isSelected?: boolean): string {
     if (!isSelected) {
       return "  ";
     }
@@ -498,7 +498,7 @@ export abstract class GenericList<
     return label;
   }
 
-  protected getBreadCrumb() {
+  protected getBreadCrumb(): string {
     if (!this.parentOptions.length || !this.settings.maxBreadcrumbItems) {
       return "";
     }
@@ -518,7 +518,7 @@ export abstract class GenericList<
     );
   }
 
-  protected getListIndex(value?: TValue) {
+  protected getListIndex(value?: TValue): number {
     return Math.max(
       0,
       typeof value === "undefined"
@@ -532,7 +532,7 @@ export abstract class GenericList<
     );
   }
 
-  protected getPageOffset(index: number) {
+  protected getPageOffset(index: number): number {
     if (index === 0) {
       return 0;
     }

--- a/prompt/deps.ts
+++ b/prompt/deps.ts
@@ -13,7 +13,7 @@ export {
   dirname,
   join,
   normalize,
-} from "@std/path/mod";
+} from "@std/path";
 export type {
   Reader,
   ReaderSync,

--- a/prompt/deps.ts
+++ b/prompt/deps.ts
@@ -8,15 +8,15 @@ export {
   stripColor,
   underline,
   yellow,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+} from "@std/fmt/colors";
 export {
   dirname,
   join,
   normalize,
-} from "https://deno.land/std@0.216.0/path/mod.ts";
+} from "@std/path/mod";
 export type {
   Reader,
   ReaderSync,
   Writer,
   WriterSync,
-} from "https://deno.land/std@0.216.0/io/types.ts";
+} from "@std/io/types";

--- a/prompt/test/prompt_list_test.ts
+++ b/prompt/test/prompt_list_test.ts
@@ -1,7 +1,7 @@
 import {
   assert,
   IsExact,
-} from "https://deno.land/x/conditional_type_checks@1.0.6/mod.ts";
+} from "conditional_type_checks";
 import { assertEquals, assertRejects } from "../../dev_deps.ts";
 import { inject, prompt } from "../prompt.ts";
 import { Checkbox } from "../checkbox.ts";

--- a/table/cell.ts
+++ b/table/cell.ts
@@ -68,7 +68,7 @@ export class Cell<TValue extends CellValue = CellValue> {
    * Any unterminated ANSI formatting overflowed from previous lines of a
    * multi-line cell.
    */
-  public get unclosedAnsiRuns() {
+  public get unclosedAnsiRuns(): string {
     return this.options.unclosedAnsiRuns ?? "";
   }
   public set unclosedAnsiRuns(val: string) {

--- a/table/deps.ts
+++ b/table/deps.ts
@@ -1,2 +1,2 @@
-export { stripColor } from "https://deno.land/std@0.216.0/fmt/colors.ts";
-export { unicodeWidth } from "https://deno.land/std@0.216.0/console/unicode_width.ts";
+export { stripColor } from "@std/fmt/colors";
+export { unicodeWidth } from "@std/console/unicode_width";

--- a/testing/deps.ts
+++ b/testing/deps.ts
@@ -1,8 +1,8 @@
-export { AssertionError } from "https://deno.land/std@0.216.0/assert/assertion_error.ts";
-export { assertSnapshot } from "https://deno.land/std@0.216.0/testing/snapshot.ts";
-export { red } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+export { AssertionError } from "@std/assert/assertion_error";
+export { assertSnapshot } from "@std/testing/snapshot";
+export { red } from "@std/fmt/colors";
 export {
   basename,
   dirname,
   fromFileUrl,
-} from "https://deno.land/std@0.216.0/path/mod.ts";
+} from "@std/path";


### PR DESCRIPTION
# Summary

Add support for [jsr](https://jsr.io/) repository.

# Motivation

Allow use of cliffy in [jsr](https://jsr.io/) packages.

# Changes

- Replace all remote url imports by `jsr` or `npm` imports.
- Add package metadatas (name and version need to be approved/updated).
- Fix all [slow types](https://jsr.io/docs/about-slow-types).
- Upgrade `deno/std` to `0.217`.