### PR TITLE
Official jsr deploy pr

### DIFF
--- a/ansi/colors.ts
+++ b/ansi/colors.ts
@@ -1,4 +1,4 @@
-import * as stdColors from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import * as stdColors from "jsr:@std/fmt@0.221.0/colors";
 
 type ExcludedColorMethods = "setColorEnabled" | "getColorEnabled";
 type PropertyNames = keyof typeof stdColors;

--- a/ansi/deps.ts
+++ b/ansi/deps.ts
@@ -1,5 +1,2 @@
-export { encodeBase64 } from "https://deno.land/std@0.216.0/encoding/base64.ts";
-export type {
-  ReaderSync,
-  WriterSync,
-} from "https://deno.land/std@0.216.0/io/types.ts";
+export { encodeBase64 } from "jsr:@std/encoding@0.221.0/base64";
+export type { ReaderSync, WriterSync } from "jsr:@std/io@0.221.0/types";

--- a/command/_utils.ts
+++ b/command/_utils.ts
@@ -1,4 +1,4 @@
-import { closestString } from "https://deno.land/std@0.216.0/text/closest_string.ts";
+import { closestString } from "jsr:@std/text@0.221.0/closest-string";
 import {
   UnexpectedArgumentAfterVariadicArgumentError,
   UnexpectedRequiredArgumentError,

--- a/command/deps.ts
+++ b/command/deps.ts
@@ -10,4 +10,4 @@ export {
   red,
   setColorEnabled,
   yellow,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+} from "jsr:@std/fmt@0.221.0/colors";

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -29,7 +29,9 @@
     "coverage:prompt": "deno task test prompt --coverage=./dist/coverage/prompt/result && deno coverage --lcov ./dist/coverage/prompt/result > ./dist/coverage/prompt/cov.lcov",
     "coverage:table": "deno task test table --coverage=./dist/coverage/table/result && deno coverage --lcov ./dist/coverage/table/result > ./dist/coverage/table/cov.lcov",
     "coverage:testing": "deno task test testing --coverage=./dist/coverage/testing/result && deno coverage --lcov ./dist/coverage/testing/result > ./dist/coverage/testing/cov.lcov",
-    "update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.5/cli.ts --ignore README.md CHANGELOG.md CONTRIBUTING.md"
+    "update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.5/cli.ts --ignore README.md CHANGELOG.md CONTRIBUTING.md",
+    "dry-publish": "deno publish --dry-run",
+    "publish": "deno publish"
     // "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -32,5 +32,24 @@
     "dry-publish": "deno publish --allow-slow-types --dry-run",
     "publish": "deno publish --allow-slow-types"
     // "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
+  },
+  "publish": {
+    "include": [
+      "ansi",
+      "command",
+      "examples",
+      "flags",
+      "keycode",
+      "keypress",
+      "prompt",
+      "table",
+      "testing",
+      "CHANGELOG.md",
+      "CONTRIBUTING.md",
+      "deno.jsonc",
+      "LICENSE",
+      "logo.png",
+      "README.md"
+    ]
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -29,8 +29,8 @@
     "coverage:table": "deno task test table --coverage=./dist/coverage/table/result && deno coverage --lcov ./dist/coverage/table/result > ./dist/coverage/table/cov.lcov",
     "coverage:testing": "deno task test testing --coverage=./dist/coverage/testing/result && deno coverage --lcov ./dist/coverage/testing/result > ./dist/coverage/testing/cov.lcov",
     "update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.5/cli.ts --ignore README.md CHANGELOG.md CONTRIBUTING.md",
-    "dry-publish": "deno publish --dry-run",
-    "publish": "deno publish"
+    "dry-publish": "deno publish --allow-slow-types --dry-run",
+    "publish": "deno publish --allow-slow-types"
     // "update": "deno run --allow-read=./ --allow-write=./ https://deno.land/x/udd@0.8.2/main.ts" globs are a bit weird in tasks: https://github.com/denoland/deno/discussions/15625
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,5 @@
 {
-  "name": "@codemonument/cliffy",
+  "name": "@cliffy-io/cliffy",
   "version": "1.0.0-rc.3",
   "exports": {
     "./ansi": "./ansi/mod.ts",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,4 +1,17 @@
 {
+  "name": "@codemonument/cliffy",
+  "version": "1.0.0-rc.3",
+  "exports": {
+    "./ansi": "./ansi/mod.ts",
+    "./command": "./command/mod.ts",
+    "./examples": "./examples/mod.ts",
+    "./flags": "./flags/mod.ts",
+    "./keycode": "./keycode/mod.ts",
+    "./keypress": "./keypress/mod.ts",
+    "./prompt": "./prompt/mod.ts",
+    "./table": "./table/mod.ts",
+    "./testing": "./testing/mod.ts"
+  },
   "lock": false,
   "exclude": ["dist"],
   "tasks": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,7 +4,6 @@
   "exports": {
     "./ansi": "./ansi/mod.ts",
     "./command": "./command/mod.ts",
-    "./examples": "./examples/mod.ts",
     "./flags": "./flags/mod.ts",
     "./keycode": "./keycode/mod.ts",
     "./keypress": "./keypress/mod.ts",

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -18,11 +18,7 @@ export {
   assertType,
   type IsExact,
 } from "https://deno.land/std@0.216.0/testing/types.ts";
-export {
-  bold,
-  red,
-  stripColor,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+export { bold, red, stripColor } from "jsr:@std/fmt@0.221.0/colors";
 export { dirname } from "https://deno.land/std@0.216.0/path/dirname.ts";
 export { expandGlob } from "https://deno.land/std@0.216.0/fs/expand_glob.ts";
 export type { WalkEntry } from "https://deno.land/std@0.216.0/fs/walk.ts";

--- a/examples/ansi/custom.ts
+++ b/examples/ansi/custom.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-net=deno.land
 
-import { rgb24 } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import { rgb24 } from "jsr:@std/fmt@0.221.0/colors";
 import { tty } from "../../ansi/tty.ts";
 
 const response = await fetch("https://deno.land/images/hashrock_simple.png");

--- a/examples/ansi/demo.ts
+++ b/examples/ansi/demo.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import * as stdColors from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import * as stdColors from "jsr:@std/fmt@0.221.0/colors";
 import * as ansiEscapes from "../../ansi/ansi_escapes.ts";
 
 const ansiEscapeNames1: Array<keyof typeof ansiEscapes> = [

--- a/examples/command/examples.ts
+++ b/examples/command/examples.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { red } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import { red } from "jsr:@std/fmt@0.221.0/colors";
 import { Command } from "../../command/command.ts";
 
 await new Command()

--- a/examples/prompt/prompt_demo.ts
+++ b/examples/prompt/prompt_demo.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run
 
-import { rgb24 } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+import { rgb24 } from "jsr:@std/fmt@0.221.0/colors";
 import { tty } from "../../ansi/tty.ts";
 import { prompt } from "../../prompt/prompt.ts";
 import { Checkbox } from "../../prompt/checkbox.ts";

--- a/examples/table/random_table_demo.ts
+++ b/examples/table/random_table_demo.ts
@@ -11,7 +11,7 @@ import {
   strikethrough,
   underline,
   yellow,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+} from "jsr:@std/fmt@0.221.0/colors";
 import { tty } from "../../ansi/tty.ts";
 import { Cell, CellType } from "../../table/cell.ts";
 import { Table } from "../../table/table.ts";

--- a/flags/deps.ts
+++ b/flags/deps.ts
@@ -1,1 +1,1 @@
-export { closestString } from "https://deno.land/std@0.216.0/text/closest_string.ts";
+export { closestString } from "jsr:@std/text@0.221.0/closest-string";

--- a/prompt/deps.ts
+++ b/prompt/deps.ts
@@ -9,11 +9,7 @@ export {
   underline,
   yellow,
 } from "jsr:@std/fmt@0.221.0/colors";
-export {
-  dirname,
-  join,
-  normalize,
-} from "https://deno.land/std@0.216.0/path/mod.ts";
+export { dirname, join, normalize } from "jsr:@std/path@0.221.0";
 export type {
   Reader,
   ReaderSync,

--- a/prompt/deps.ts
+++ b/prompt/deps.ts
@@ -15,5 +15,5 @@ export type {
   ReaderSync,
   Writer,
   WriterSync,
-} from "https://deno.land/std@0.216.0/io/types.ts";
-export { levenshteinDistance } from "https://deno.land/std@0.216.0/text/levenshtein_distance.ts";
+} from "jsr:@std/io@0.221.0/types";
+export { levenshteinDistance } from "jsr:@std/text@0.221.0/levenshtein-distance";

--- a/prompt/deps.ts
+++ b/prompt/deps.ts
@@ -8,7 +8,7 @@ export {
   stripColor,
   underline,
   yellow,
-} from "https://deno.land/std@0.216.0/fmt/colors.ts";
+} from "jsr:@std/fmt@0.221.0/colors";
 export {
   dirname,
   join,

--- a/table/deps.ts
+++ b/table/deps.ts
@@ -1,2 +1,2 @@
-export { stripColor } from "https://deno.land/std@0.216.0/fmt/colors.ts";
+export { stripColor } from "jsr:@std/fmt@0.221.0/colors";
 export { unicodeWidth } from "https://deno.land/std@0.216.0/console/unicode_width.ts";

--- a/table/deps.ts
+++ b/table/deps.ts
@@ -1,2 +1,2 @@
 export { stripColor } from "jsr:@std/fmt@0.221.0/colors";
-export { unicodeWidth } from "https://deno.land/std@0.216.0/console/unicode_width.ts";
+export { unicodeWidth } from "jsr:@std/console@0.221.0/unicode-width";

--- a/table/test/ansi_regex_source_test.ts
+++ b/table/test/ansi_regex_source_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "../../dev_deps.ts";
 Deno.test(`table - ansiRegexSource`, () => {
   const DIGITS = String.raw`\d+`;
   // All open and close ANSI codes taken from calls to `code(...)` in
-  // https://deno.land/std@0.216.0/fmt/colors.ts
+  // jsr:@std/fmt@0.221.0/colors
   const ansiCodes = [
     { open: [0], close: 0 },
     { open: [1], close: 22 },

--- a/testing/deps.ts
+++ b/testing/deps.ts
@@ -1,8 +1,4 @@
-export { AssertionError } from "https://deno.land/std@0.216.0/assert/assertion_error.ts";
-export { assertSnapshot } from "https://deno.land/std@0.216.0/testing/snapshot.ts";
-export { red } from "https://deno.land/std@0.216.0/fmt/colors.ts";
-export {
-  basename,
-  dirname,
-  fromFileUrl,
-} from "https://deno.land/std@0.216.0/path/mod.ts";
+export { AssertionError } from "jsr:@std/assert@0.221.0";
+export { assertSnapshot } from "jsr:@std/testing@0.221.0/snapshot";
+export { red } from "jsr:@std/fmt@0.221.0/colors";
+export { basename, dirname, fromFileUrl } from "jsr:@std/path@0.221.0";


### PR DESCRIPTION
Hi @c4spar ! 

Since deno's new registry [jsr](https://jsr.io) launched, it's a little complicated to use cliffy with it, since you cannot publish code to jsr which uses http imports. 

Therefore I made the minimum  necessary changes to be able to publish this lib to jsr. 
Since I simply swapped out the imports with jsr std imports, it should still be possible to publish this on deno.land/x as is. 

Here is the example of the working publish (under one of my scopes - codemonument): 
https://jsr.io/@codemonument/cliffy/versions

It would be nice if you could accept this! 

> [!INFO]
> Please review the scope name for this package. I chose @cliffy-io as the scope for now, because we may be able to publish more things under there, like more custom types, etc. 
> But you can also choose your own c4spar name as the scope. 
> jsr only requires any scope. 