### PR TITLE
feat(command): parse without execute

### DIFF
--- a/examples/command/parse_no_execute.ts
+++ b/examples/command/parse_no_execute.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S deno run
+
+import { Command } from '../../command/command.ts';
+import { CompletionsCommand } from '../../command/completions/completions_command.ts';
+import { HelpCommand } from '../../command/help/help_command.ts';
+
+function getCommandFullname(command: Command<any> | undefined): string {
+  const names = [];
+  let cmd = command;
+
+  while (cmd !== undefined) {
+    names.push(cmd.getName());
+    cmd = cmd.getParent();
+  }
+
+  return names.reverse().join('-');
+}
+
+const rootCommand = new Command()
+  .name('cliffy')
+  .version('1.0.0')
+  .description(`Command line framework for Deno`)
+  .option('-p, --beep', 'Some option.', {
+    default: true,
+  })
+  .option('--no-beep', 'Negate beep.')
+  .option('-f, --foo [value:string]', 'Some string value.', {
+    default: 'foo',
+  })
+  .option('-b, --bar [value:number]', 'Some numeric value.', {
+    default: 89,
+    depends: ['foo'],
+  })
+  .option('-B, --baz <value:boolean>', 'Some boolean value.', {
+    conflicts: ['beep'],
+  })
+  .command('help', new HelpCommand().global())
+  .command('completions', new CompletionsCommand());
+
+const { cmd, options, literal } = await rootCommand.parse(Deno.args, {
+  execute: false,
+});
+
+const fullname = getCommandFullname(cmd);
+
+console.log('Command:', fullname);
+console.log('Options:', options);
+console.log('Literal:', literal);
+
+await globalThis.window.prompt('Press enter to execute...');
+
+await cmd.execute(options, literal);


### PR DESCRIPTION
closes #647

@c4spar - This is a very early draft at implementing your suggested approach to allow the `parse` method to be called without executing. I've got this mostly working with minimal changes. However there are a couple of initial things I'm not sure how to proceed with and would love your guidance/suggestions:

1. The options action handlers (e.g. `--help`) are not executed inside `parseCommand` and not by the `execute` function. The `ParsingContext` is the only thing that tracks these actions at the moment, and I suspect we don't want to expose that. We likely this needs to be unified into the execute command somehow?
2. To avoid messing with types too much I'm re-using the `literal` field in place of `args` which satisfies the return type shape. However, the current name `literal` isn't the most intuitive either imo. Maybe it makes sense to rename `literal` to `args` if possible?

I've added an example which demonstrates the current usage. It seems to mostly work except for when passing `--help`. I've also added some inline comments on areas I think need work.