### PR TITLE
feat(command): :sparkles: add `Editor` prompt type

### DIFF
--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -11,8 +11,12 @@ import { normalize } from "@std/path";
 /** Editor prompt options. */
 export interface EditorOptions
   extends GenericSuggestionsOptions<string, string> {
-  /** Prompt end delimiter. */
-  endDelimiter?: string;
+  /** Edit an existing file. */
+  sourceFile?: string;
+  /** Prefer editor mode. */
+  preferMode?: 'terminal' | 'visual';
+  /** Temp file extension. */
+  fileExtension?: string;
   /** Set minimum allowed length of editor value. */
   minLength?: number;
   /** Set maximum allowed length of editor value. */
@@ -21,9 +25,11 @@ export interface EditorOptions
 
 /** Editor prompt settings. */
 interface EditorSettings extends GenericSuggestionsSettings<string, string> {
+  sourceFile: string;
+  preferMode: 'editor' | 'visual';
+  fileExtension: string;
   minLength: number;
   maxLength: number;
-  endDelimiter: string;
 }
 
 /**
@@ -32,7 +38,7 @@ interface EditorSettings extends GenericSuggestionsSettings<string, string> {
  * ```ts
  * import { Editor } from "./mod.ts";
  *
- * const confirmed: string = await Editor.prompt("Enter your name");
+ * const noteContent: string = await Editor.prompt("Edit a note");
  * ```
  */
 export class Editor extends GenericSuggestions<string, string> {

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -71,13 +71,23 @@ export class Editor extends GenericSuggestions<string, string> {
   }
 
   public getDefaultSettings(options: EditorOptions): EditorSettings {
+    const editor = `${brightBlack("(")}${brightBlue("EDITOR")}${brightBlack(")")}`
+    const bOpen = brightBlack("[")
+    const bClose = brightBlack("]")
+    const yLink = (path: string) => yellow(link(path, resolve(path)))
+
+    const hasSourceFile = 'sourceFile' in options && options.sourceFile !== undefined
+
+    const pointer = hasSourceFile ?
+      `${editor} ${bOpen}${yLink(options.sourceFile!)}${bClose}` :
+      editor
+
     return {
       ...super.getDefaultSettings(options),
-      pointer: options.pointer ??
-        `${brightBlack("EOF: (")}${brightBlue(options.endDelimiter ?? ".")}${
-          brightBlack(")")
-        }`,
-      endDelimiter: options.endDelimiter ?? ".",
+      pointer: options.pointer ?? pointer,
+      sourceFile: hasSourceFile ? options.sourceFile! : Deno.makeTempFileSync({ suffix: options.fileExtension }),
+      suggestedEditor: options.suggestedEditor ?? '',
+      editorMode: 'terminal',
       minLength: options.minLength ?? 0,
       maxLength: options.maxLength ?? Infinity,
     };

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -78,9 +78,12 @@ export class Editor extends GenericSuggestions<string, string> {
 
     const hasSourceFile = 'sourceFile' in options && options.sourceFile !== undefined
 
-    const pointer = hasSourceFile ?
-      `${editor} ${bOpen}${yLink(options.sourceFile!)}${bClose}` :
-      editor
+    const pointer = 
+      hasSourceFile ?
+        `${editor} ${bOpen}${yLink(options.sourceFile!)}${bClose}` :
+      options.fileExtension ?
+        `${editor} ${bOpen}${brightBlack("ext: ")}${yellow(options.fileExtension)}${bClose}` :
+        editor
 
     return {
       ...super.getDefaultSettings(options),

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -108,8 +108,8 @@ export class Editor extends GenericSuggestions<string, string> {
       // try $EDITOR then $VISUAL global vars, else git user defined editor, else vim, else vscode, else notepad
       ? '"$($EDITOR ?? $VISUAL ?? $($(git config core.editor) 2> $null) ?? $($(vim -h) 2>&1> $null && echo "vim") ?? $($(code -h) 2>&1> $null && echo "code") ?? $(echo "notepad"))"'
       //sh
-      // try $EDITOR then $VISUAL global vars, else git user defined editor, else os terminal defined editor is available, else vi
-      : '"${EDITOR:-${VISUAL:-$(git config core.editor 2> /dev/null || (sensible-editor --version &> /dev/null && echo "sensible-editor") || echo "vi")}}"';
+  async #queryEditor(shQuery: string, pwshQuery: string): Promise<string> {
+    const queryEditor = Deno.build.os === "windows" ? pwshQuery : shQuery;
 
     const { stdout, stderr, success } = await new Deno.Command(this.#osShell, {
       args: [...this.#osShellArgs, `echo ${queryEditor}`],
@@ -120,7 +120,7 @@ export class Editor extends GenericSuggestions<string, string> {
     if (success) {
       return decoder.decode(stdout).trim();
     } else {
-      throw new Error("unable to determine user default terminal editor", {
+      throw new Error("unable to determine user default editor", {
         cause: new Error(decoder.decode(stderr).trim()),
       });
     }

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -16,7 +16,7 @@ export interface EditorOptions
   /** Temp file extension. */
   fileExtension?: string;
   /** Prefer editor mode. */
-  editorMode?: 'terminal' | 'visual';
+  editorMode?: "terminal" | "visual";
   /** Suggest editor to use in priority. */
   suggestedEditor?: string;
   /** Set minimum allowed length of editor value. */
@@ -29,7 +29,7 @@ export interface EditorOptions
 interface EditorSettings extends GenericSuggestionsSettings<string, string> {
   sourceFile: string;
   fileExtension: string;
-  editorMode: 'terminal' | 'visual';
+  editorMode: "terminal" | "visual";
   suggestedEditor: string;
   minLength: number;
   maxLength: number;
@@ -72,27 +72,31 @@ export class Editor extends GenericSuggestions<string, string> {
   }
 
   public getDefaultSettings(options: EditorOptions): EditorSettings {
-    const editor = `${brightBlack("(")}${brightBlue("EDITOR")}${brightBlack(")")}`
-    const bOpen = brightBlack("[")
-    const bClose = brightBlack("]")
-    const yLink = (path: string) => yellow(link(path, resolve(path)))
+    const editor = `${brightBlack("(")}${brightBlue("EDITOR")}${
+      brightBlack(")")
+    }`;
+    const bOpen = brightBlack("[");
+    const bClose = brightBlack("]");
+    const yLink = (path: string) => yellow(link(path, resolve(path)));
 
-    const hasSourceFile = 'sourceFile' in options && options.sourceFile !== undefined
+    const hasSourceFile = "sourceFile" in options &&
+      options.sourceFile !== undefined;
 
-    const pointer = 
-      hasSourceFile ?
-        `${editor} ${bOpen}${yLink(options.sourceFile!)}${bClose}` :
-      options.fileExtension ?
-        `${editor} ${bOpen}${brightBlack("ext: ")}${yellow(options.fileExtension)}${bClose}` :
-        editor
+    const pointer = hasSourceFile
+      ? `${editor} ${bOpen}${yLink(options.sourceFile!)}${bClose}`
+      : options.fileExtension
+      ? `${editor} ${bOpen}${brightBlack("ext: ")}${
+        yellow(options.fileExtension)
+      }${bClose}`
+      : editor;
 
     return {
       ...super.getDefaultSettings(options),
       pointer: options.pointer ?? pointer,
-      sourceFile: options.sourceFile ?? '',
-      fileExtension: options.fileExtension ?? '',
-      suggestedEditor: options.suggestedEditor ?? '',
-      editorMode: 'terminal',
+      sourceFile: options.sourceFile ?? "",
+      fileExtension: options.fileExtension ?? "",
+      suggestedEditor: options.suggestedEditor ?? "",
+      editorMode: "terminal",
       minLength: options.minLength ?? 0,
       maxLength: options.maxLength ?? Infinity,
     };
@@ -106,23 +110,25 @@ export class Editor extends GenericSuggestions<string, string> {
     return Deno.build.os === "windows" ? ["-nop", "-c"] : ["-c"];
   }
 
-  
   #getDefaultVisualEditor(): Promise<string> {
     const sh = {
-      custom: `(which "${this.settings.suggestedEditor}" &> /dev/null && echo "${this.settings.suggestedEditor}")`,
-      xdgText: '(gtk-launch $(xdg-mime query default text/plain) --version &> /dev/null && echo "gtk-launch $(xdg-mime query default text/plain)")',
+      custom:
+        `(which "${this.settings.suggestedEditor}" &> /dev/null && echo "${this.settings.suggestedEditor}")`,
+      xdgText:
+        '(gtk-launch $(xdg-mime query default text/plain) --version &> /dev/null && echo "gtk-launch $(xdg-mime query default text/plain)")',
       gedit: '(gedit --version &> /dev/null && echo "gedit")',
-      gvim: 'echo "gvim"'
-    }
+      gvim: 'echo "gvim"',
+    };
 
     const pwsh = {
-      custom: `$($(Get-Command "${this.settings.suggestedEditor}") 2>&1> $null && echo "${this.settings.suggestedEditor}")`,
+      custom:
+        `$($(Get-Command "${this.settings.suggestedEditor}") 2>&1> $null && echo "${this.settings.suggestedEditor}")`,
       code: '$($(code -h) 2>&1> $null && echo "code")',
       sublime: '$($(subl -h) 2>&1> $null && echo "subl")',
       gvim: '$($(gvim -h) 2>&1> $null && echo "gvim")',
       notepadPLusPlus: '$($(notepad++ --help) 2>&1> $null && echo "notepad++")',
-      notepad: '$(echo "notepad")'
-    }
+      notepad: '$(echo "notepad")',
+    };
 
     return this.#queryEditor(
       //sh
@@ -130,24 +136,27 @@ export class Editor extends GenericSuggestions<string, string> {
       `"\${VISUAL:-$(${sh.custom} || ${sh.xdgText} || ${sh.gedit} || ${sh.gvim})}"`,
       //pwsh
       // try $VISUAL global var then custom if provided, else sublime text, else notepad++, else gvim, else notepad
-      `"$($VISUAL ?? $(${pwsh.custom} ?? ${pwsh.code} ?? ${pwsh.sublime} ?? ${pwsh.notepadPLusPlus} ?? ${pwsh.gvim} ?? ${pwsh.notepad})"`
-    )
+      `"$($VISUAL ?? $(${pwsh.custom} ?? ${pwsh.code} ?? ${pwsh.sublime} ?? ${pwsh.notepadPLusPlus} ?? ${pwsh.gvim} ?? ${pwsh.notepad})"`,
+    );
   }
   #getDefaultTerminalEditor(): Promise<string> {
     const sh = {
-      custom: `(which "${this.settings.suggestedEditor}" &> /dev/null && echo "${this.settings.suggestedEditor}")`,
+      custom:
+        `(which "${this.settings.suggestedEditor}" &> /dev/null && echo "${this.settings.suggestedEditor}")`,
       git: "git config core.editor 2> /dev/null",
-      sensible: '(sensible-editor --version &> /dev/null && echo "sensible-editor")',
+      sensible:
+        '(sensible-editor --version &> /dev/null && echo "sensible-editor")',
       vi: '(vi --version &> /dev/null && echo "vi")',
-      nano: 'echo "nano"'
-    }
+      nano: 'echo "nano"',
+    };
 
     const pwsh = {
-      custom: `$($(Get-Command "${this.settings.suggestedEditor}") 2>&1> $null && echo "${this.settings.suggestedEditor}")`,
+      custom:
+        `$($(Get-Command "${this.settings.suggestedEditor}") 2>&1> $null && echo "${this.settings.suggestedEditor}")`,
       git: "$(git config core.editor) 2> $null)",
       vim: '$($(vim -h) 2>&1> $null && echo "vim")',
-      notepad: '$(echo "notepad")'
-    }
+      notepad: '$(echo "notepad")',
+    };
 
     return this.#queryEditor(
       //sh
@@ -155,10 +164,10 @@ export class Editor extends GenericSuggestions<string, string> {
       `"\${EDITOR:-$(${sh.custom} || ${sh.git} || ${sh.sensible} || ${sh.vi} || ${sh.nano})}"`,
       //pwsh
       // try $EDITOR global var then custom if provided, else git user defined editor, else vim, default notepad (required fallback despite terminal mode).
-      `"$($EDITOR ?? $(${pwsh.custom} ?? ${pwsh.git} ?? ${pwsh.vim} ?? ${pwsh.notepad})"`
-    )
+      `"$($EDITOR ?? $(${pwsh.custom} ?? ${pwsh.git} ?? ${pwsh.vim} ?? ${pwsh.notepad})"`,
+    );
   }
-  
+
   async #queryEditor(shQuery: string, pwshQuery: string): Promise<string> {
     const queryEditor = Deno.build.os === "windows" ? pwshQuery : shQuery;
 
@@ -183,9 +192,12 @@ export class Editor extends GenericSuggestions<string, string> {
     //Show default prompt
     await super.prompt();
 
-    const filePath = this.settings.sourceFile ?? await Deno.makeTempFile({ suffix: `.${this.settings.fileExtension}` });
+    const filePath = this.settings.sourceFile ??
+      await Deno.makeTempFile({ suffix: `.${this.settings.fileExtension}` });
 
-    const editor = this.settings.editorMode === 'visual' ? await this.#getDefaultVisualEditor() : await this.#getDefaultTerminalEditor();
+    const editor = this.settings.editorMode === "visual"
+      ? await this.#getDefaultVisualEditor()
+      : await this.#getDefaultTerminalEditor();
 
     //open editor
     const { success } = await new Deno.Command(this.#osShell, {

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -13,10 +13,12 @@ export interface EditorOptions
   extends GenericSuggestionsOptions<string, string> {
   /** Edit an existing file. */
   sourceFile?: string;
-  /** Prefer editor mode. */
-  preferMode?: 'terminal' | 'visual';
   /** Temp file extension. */
   fileExtension?: string;
+  /** Prefer editor mode. */
+  editorMode?: 'terminal' | 'visual';
+  /** Suggest editor to use in priority. */
+  suggestedEditor?: string;
   /** Set minimum allowed length of editor value. */
   minLength?: number;
   /** Set maximum allowed length of editor value. */
@@ -26,8 +28,8 @@ export interface EditorOptions
 /** Editor prompt settings. */
 interface EditorSettings extends GenericSuggestionsSettings<string, string> {
   sourceFile: string;
-  preferMode: 'editor' | 'visual';
-  fileExtension: string;
+  editorMode: 'terminal' | 'visual';
+  suggestedEditor: string;
   minLength: number;
   maxLength: number;
 }

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -1,0 +1,188 @@
+import { brightBlack, brightBlue } from "jsr:@std/fmt@0.224/colors";
+import { GenericPrompt } from "./_generic_prompt.ts";
+import {
+  GenericSuggestions,
+  GenericSuggestionsKeys,
+  GenericSuggestionsOptions,
+  GenericSuggestionsSettings,
+} from "./_generic_suggestions.ts";
+import { normalize } from "@std/path";
+
+/** Editor prompt options. */
+export interface EditorOptions
+  extends GenericSuggestionsOptions<string, string> {
+  /** Prompt end delimiter. */
+  endDelimiter?: string;
+  /** Set minimum allowed length of editor value. */
+  minLength?: number;
+  /** Set maximum allowed length of editor value. */
+  maxLength?: number;
+}
+
+/** Editor prompt settings. */
+interface EditorSettings extends GenericSuggestionsSettings<string, string> {
+  minLength: number;
+  maxLength: number;
+  endDelimiter: string;
+}
+
+/**
+ * Editor prompt representation.
+ *
+ * ```ts
+ * import { Editor } from "./mod.ts";
+ *
+ * const confirmed: string = await Editor.prompt("Enter your name");
+ * ```
+ */
+export class Editor extends GenericSuggestions<string, string> {
+  protected readonly settings: EditorSettings;
+
+  /** Execute the prompt with provided options. */
+  public static prompt(options: string | EditorOptions): Promise<string> {
+    return new this(options).prompt();
+  }
+
+  /**
+   * Inject prompt value. If called, the prompt doesn't prompt for an input and
+   * returns immediately the injected value. Can be used for unit tests or pre
+   * selections.
+   *
+   * @param value Input value.
+   */
+  public static inject(value: string): void {
+    GenericPrompt.inject(value);
+  }
+
+  constructor(options: string | EditorOptions) {
+    super();
+    if (typeof options === "string") {
+      options = { message: options };
+    }
+    this.settings = this.getDefaultSettings(options);
+  }
+
+  public getDefaultSettings(options: EditorOptions): EditorSettings {
+    return {
+      ...super.getDefaultSettings(options),
+      pointer: options.pointer ??
+        `${brightBlack("EOF: (")}${brightBlue(options.endDelimiter ?? ".")}${
+          brightBlack(")")
+        }`,
+      endDelimiter: options.endDelimiter ?? ".",
+      minLength: options.minLength ?? 0,
+      maxLength: options.maxLength ?? Infinity,
+    };
+  }
+
+  get #osShell(): string {
+    return Deno.build.os === "windows" ? "pwsh" : "bash";
+  }
+
+  get #osShellArgs(): string[] {
+    return Deno.build.os === "windows" ? ["-nop", "-c"] : ["-c"];
+  }
+
+  async #getDefaultEditor(): Promise<string> {
+    //? Maybe refactor these lines to an helper function
+    const queryEditor = Deno.build.os === "windows"
+      //pwsh
+      // try $EDITOR then $VISUAL global vars, else git user defined editor, else vim, else vscode, else notepad
+      ? '"$($EDITOR ?? $VISUAL ?? $($(git config core.editor) 2> $null) ?? $($(vim -h) 2>&1> $null && echo "vim") ?? $($(code -h) 2>&1> $null && echo "code") ?? $(echo "notepad"))"'
+      //sh
+      // try $EDITOR then $VISUAL global vars, else git user defined editor, else os terminal defined editor is available, else vi
+      : '"${EDITOR:-${VISUAL:-$(git config core.editor 2> /dev/null || (sensible-editor --version &> /dev/null && echo "sensible-editor") || echo "vi")}}"';
+
+    const { stdout, stderr, success } = await new Deno.Command(this.#osShell, {
+      args: [...this.#osShellArgs, `echo ${queryEditor}`],
+    }).output();
+
+    const decoder = new TextDecoder();
+
+    if (success) {
+      return decoder.decode(stdout).trim();
+    } else {
+      throw new Error("unable to determine user default terminal editor", {
+        cause: new Error(decoder.decode(stderr).trim()),
+      });
+    }
+  }
+
+  public async prompt() {
+    //TODO fix stdin error
+    GenericPrompt.inject("\n");
+    //Show default prompt
+    await super.prompt();
+
+    const tmpFilePath = await Deno.makeTempFile();
+
+    const editor = await this.#getDefaultEditor();
+
+    //open editor
+    const { success } = await new Deno.Command(this.#osShell, {
+      args: [...this.#osShellArgs, `${editor} ${tmpFilePath}`],
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "inherit",
+    }).output();
+
+    if (!success) {
+      throw new Error(
+        `unable to open detected user defined editor (${editor})`,
+      );
+    }
+
+    const content = await Deno.readTextFile(tmpFilePath);
+    await Deno.remove(tmpFilePath);
+
+    return content;
+  }
+
+  protected success(value: string): string | undefined {
+    //TODO
+    this.saveSuggestions(value);
+    return super.success(value);
+  }
+
+  /** Get editor value. */
+  protected getValue(): string {
+    //TODO
+    return this.settings.files ? normalize(this.inputValue) : this.inputValue;
+  }
+
+  /**
+   * Validate editor value.
+   * @param value User input value.
+   * @return True on success, false or error message on error.
+   */
+  protected validate(value: string): boolean | string {
+    if (typeof value !== "string") {
+      return false;
+    }
+    if (value.length < this.settings.minLength) {
+      return `Value must be longer than ${this.settings.minLength} but has a length of ${value.length}.`;
+    }
+    if (value.length > this.settings.maxLength) {
+      return `Value can't be longer than ${this.settings.maxLength} but has a length of ${value.length}.`;
+    }
+    return true;
+  }
+
+  /**
+   * Map input value to output value.
+   * @param value Input value.
+   * @return Output value.
+   */
+  protected transform(value: string): string | undefined {
+    //TODO
+    return value.trim();
+  }
+
+  /**
+   * Format output value.
+   * @param value Output value.
+   */
+  protected format(value: string): string {
+    return value;
+  }
+}

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -1,12 +1,12 @@
-import { brightBlack, brightBlue } from "jsr:@std/fmt@0.224/colors";
+import { brightBlack, brightBlue, yellow } from "jsr:@std/fmt@0.224/colors";
 import { GenericPrompt } from "./_generic_prompt.ts";
 import {
   GenericSuggestions,
-  GenericSuggestionsKeys,
   GenericSuggestionsOptions,
   GenericSuggestionsSettings,
 } from "./_generic_suggestions.ts";
-import { normalize } from "@std/path";
+import { normalize, resolve } from "@std/path";
+import { link } from "../ansi/ansi_escapes.ts";
 
 /** Editor prompt options. */
 export interface EditorOptions

--- a/prompt/editor.ts
+++ b/prompt/editor.ts
@@ -28,6 +28,7 @@ export interface EditorOptions
 /** Editor prompt settings. */
 interface EditorSettings extends GenericSuggestionsSettings<string, string> {
   sourceFile: string;
+  fileExtension: string;
   editorMode: 'terminal' | 'visual';
   suggestedEditor: string;
   minLength: number;
@@ -88,7 +89,8 @@ export class Editor extends GenericSuggestions<string, string> {
     return {
       ...super.getDefaultSettings(options),
       pointer: options.pointer ?? pointer,
-      sourceFile: hasSourceFile ? options.sourceFile! : Deno.makeTempFileSync({ suffix: options.fileExtension }),
+      sourceFile: options.sourceFile ?? '',
+      fileExtension: options.fileExtension ?? '',
       suggestedEditor: options.suggestedEditor ?? '',
       editorMode: 'terminal',
       minLength: options.minLength ?? 0,


### PR DESCRIPTION
# Summary

Add user defined terminal editor prompt type (`Editor`).

# Motivation

Allow full featured terminal (or ui) editor prompt.

# Changes

- Add `prompt/editor.ts`.

# Todo

- Add validations.
- Add options (maybe prefered implementer editor, only terminal or visual edito, ...).
- Implement fully (all methods).
- Add tests.
- Add doc.

Maybe choose a better name: "TextEditor", ...
