### PR TITLE
chore(lint): Remove unused null coalescing operator

### DIFF
--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -358,7 +358,7 @@ export class HelpGenerator {
 }
 
 function capitalize(string: string): string {
-  return string?.charAt(0).toUpperCase() + string.slice(1);
+  return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 function inspect(value: unknown, colors: boolean): string {

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -358,7 +358,7 @@ export class HelpGenerator {
 }
 
 function capitalize(string: string): string {
-  return string?.charAt(0).toUpperCase() + string.slice(1) ?? "";
+  return string?.charAt(0).toUpperCase() + string.slice(1);
 }
 
 function inspect(value: unknown, colors: boolean): string {


### PR DESCRIPTION
Was alerted while building a project using cliffy:

```
    https://deno.land/x/cliffy@v1.0.0-rc.3/command/help/_help_generator.ts:354:59:
      354 │   return string?.charAt(0).toUpperCase() + string.slice(1) ?? "";
          ╵                                                            ~~

  The left operand of the "??" operator here will never be null or undefined, so it will always be
  returned. This usually indicates a bug in your code:

    https://deno.land/x/cliffy@v1.0.0-rc.3/command/help/_help_generator.ts:354:9:
      354 │   return string?.charAt(0).toUpperCase() + string.slice(1) ?? "";
          ╵          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

for the input `""`, the return value is already `""`. `null` and `undefined` both raise `TypeError`s.