### PR TITLE
fix(internal): Use Bun.stdin when using Bun to prevent process hanging

### DIFF
--- a/internal/runtime/read.ts
+++ b/internal/runtime/read.ts
@@ -4,14 +4,22 @@
  * @internal
  * @param data Uint8Array to store the data.
  */
-export function read(data: Uint8Array): Promise<number | null> {
+export async function read(data: Uint8Array): Promise<number | null> {
   // deno-lint-ignore no-explicit-any
-  const { Deno, process } = globalThis as any;
+  const { Deno, Bun, process } = globalThis as any;
 
   if (Deno) {
-    return Deno.stdin.read(data);
+    return await Deno.stdin.read(data);
+  } else if (Bun) {
+    const reader = Bun.stdin.stream().getReader();
+    const { value: buffer } = await reader.read();
+    await reader.cancel();
+    for (let i = 0; i < buffer.length; i++) {
+      data[i] = buffer[i];
+    }
+    return buffer.length;
   } else if (process) {
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       process.stdin.once("readable", () => {
         try {
           const buffer = process.stdin.read();


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### fix(internal): Use Bun.stdin when using Bun to prevent process hanging

Bun's node:process stdin implementation has multiple issues related to
raw mode, resuming, and ending it too early.

To work around this, this adds a custom branch for the read function
when running under Bun. It uses Bun's own stdin implementation to read
one chunk and then dispose the reader.

Fixes #759
<!-- pr-cli body end -->