### PR TITLE
feat: Build help text based on terminal width, adjust column widths dynamically

### DIFF
--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -134,7 +134,7 @@ export class HelpGenerator {
       ])
         .indent(this.indent)
         .maxColWidth(this.width - this.indent)
-        .colRigidity(0)
+        .flexShrink(1)
         .padding(1)
         .toString() +
       "\n";
@@ -227,7 +227,7 @@ export class HelpGenerator {
           .padding([2, 2, 1, 2])
           .indent(this.indent)
           .maxTableWidth(this.width - this.indent)
-          .colRigidity([1, 1, 1, 0, 0])
+          .flexShrink([0, 0, 0, 1, 1])
           .maxColWidth([60, 60, 1, 80, 60])
           .toString() +
         "\n";
@@ -244,7 +244,7 @@ export class HelpGenerator {
       ])
         .indent(this.indent)
         .maxTableWidth(this.width - this.indent)
-        .colRigidity([1, 1, 1, 0])
+        .flexShrink([0, 0, 0, 1])
         .maxColWidth([60, 1, 80, 60])
         .padding([2, 1, 2])
         .toString() +
@@ -278,7 +278,7 @@ export class HelpGenerator {
         ])
           .indent(this.indent)
           .maxTableWidth(this.width - this.indent)
-          .colRigidity([1, 1, 1, 0])
+          .flexShrink([0, 0, 0, 1])
           .maxColWidth([60, 60, 1, 80])
           .padding([2, 2, 1, 2])
           .toString() +
@@ -297,7 +297,7 @@ export class HelpGenerator {
         ]),
       ])
         .maxTableWidth(this.width - this.indent)
-        .colRigidity([1, 1, 0])
+        .flexShrink([0, 0, 1])
         .maxColWidth([60, 1, 80])
         .padding([2, 1, 2])
         .indent(this.indent)
@@ -328,7 +328,7 @@ export class HelpGenerator {
         .padding([2, 2, 1, 2])
         .indent(this.indent)
         .maxTableWidth(this.width - this.indent)
-        .colRigidity([1, 1, 1, 0, 0])
+        .flexShrink([0, 0, 0, 1, 1])
         .maxColWidth([60, 60, 1, 80, 10])
         .toString() +
       "\n";

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -11,8 +11,8 @@ import {
   setColorEnabled,
   yellow,
 } from "@std/fmt/colors";
-import { inspect } from "@cliffy/internal/runtime/inspect";
 import { getColumns } from "@cliffy/internal/runtime/get-columns";
+import { inspect } from "@cliffy/internal/runtime/inspect";
 import {
   dedent,
   getDescription,
@@ -56,7 +56,8 @@ export class HelpGenerator {
     private cmd: Command,
     options: HelpOptions = {},
   ) {
-    this.width = Math.min(getColumns() ?? 150, 150);
+    this.width = getColumns() ?? 150;
+
     this.options = {
       types: false,
       hints: true,
@@ -134,7 +135,6 @@ export class HelpGenerator {
       ])
         .indent(this.indent)
         .maxColWidth(this.width - this.indent)
-        .flexShrink(1)
         .padding(1)
         .toString() +
       "\n";
@@ -162,6 +162,8 @@ export class HelpGenerator {
       ])
         .padding([2, 1, 2])
         .indent(this.indent)
+        .maxTableWidth(this.width - this.indent)
+        .flexShrink([0, 0, 1, 1])
         .maxColWidth([60, 1, 80, 60])
         .toString() +
       "\n";
@@ -347,6 +349,7 @@ export class HelpGenerator {
         .padding(1)
         .indent(this.indent)
         .maxTableWidth(this.width - this.indent)
+        .flexShrink([0, 1])
         .toString() +
       "\n";
   }

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -44,6 +44,7 @@ interface OptionGroup {
 export class HelpGenerator {
   private indent = 2;
   private options: Required<HelpOptions>;
+  private width: number;
 
   /** Generate help text for given command. */
   public static generate(cmd: Command, options?: HelpOptions): string {
@@ -54,6 +55,7 @@ export class HelpGenerator {
     private cmd: Command,
     options: HelpOptions = {},
   ) {
+    this.width = Math.min(Deno.consoleSize()?.columns, 150);
     this.options = {
       types: false,
       hints: true,
@@ -130,7 +132,8 @@ export class HelpGenerator {
         [dedent(this.cmd.getDescription())],
       ])
         .indent(this.indent)
-        .maxColWidth(140)
+        .maxColWidth(this.width - this.indent)
+        .colRigidity(0)
         .padding(1)
         .toString() +
       "\n";
@@ -222,6 +225,8 @@ export class HelpGenerator {
         ])
           .padding([2, 2, 1, 2])
           .indent(this.indent)
+          .maxTableWidth(this.width - this.indent)
+          .colRigidity([1, 1, 1, 0, 0])
           .maxColWidth([60, 60, 1, 80, 60])
           .toString() +
         "\n";
@@ -237,6 +242,8 @@ export class HelpGenerator {
         ]),
       ])
         .indent(this.indent)
+        .maxTableWidth(this.width - this.indent)
+        .colRigidity([1, 1, 1, 0])
         .maxColWidth([60, 1, 80, 60])
         .padding([2, 1, 2])
         .toString() +
@@ -269,6 +276,8 @@ export class HelpGenerator {
           ]),
         ])
           .indent(this.indent)
+          .maxTableWidth(this.width - this.indent)
+          .colRigidity([1, 1, 1, 0])
           .maxColWidth([60, 60, 1, 80])
           .padding([2, 2, 1, 2])
           .toString() +
@@ -286,6 +295,8 @@ export class HelpGenerator {
           command.getShortDescription(),
         ]),
       ])
+        .maxTableWidth(this.width - this.indent)
+        .colRigidity([1, 1, 0])
         .maxColWidth([60, 1, 80])
         .padding([2, 1, 2])
         .indent(this.indent)
@@ -315,6 +326,8 @@ export class HelpGenerator {
       ])
         .padding([2, 2, 1, 2])
         .indent(this.indent)
+        .maxTableWidth(this.width - this.indent)
+        .colRigidity([1, 1, 1, 0, 0])
         .maxColWidth([60, 60, 1, 80, 10])
         .toString() +
       "\n";
@@ -332,7 +345,7 @@ export class HelpGenerator {
       ]))
         .padding(1)
         .indent(this.indent)
-        .maxColWidth(150)
+        .maxTableWidth(this.width - this.indent)
         .toString() +
       "\n";
   }

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -12,6 +12,7 @@ import {
   yellow,
 } from "@std/fmt/colors";
 import { inspect } from "@cliffy/internal/runtime/inspect";
+import { getColumns } from "@cliffy/internal/runtime/get-columns";
 import {
   dedent,
   getDescription,
@@ -55,11 +56,7 @@ export class HelpGenerator {
     private cmd: Command,
     options: HelpOptions = {},
   ) {
-    try {
-      this.width = Math.min(Deno.consoleSize().columns, 150);
-    } catch (_err) {
-      this.width = 150;
-    }
+    this.width = Math.min(getColumns() ?? 150, 150);
     this.options = {
       types: false,
       hints: true,

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -55,7 +55,11 @@ export class HelpGenerator {
     private cmd: Command,
     options: HelpOptions = {},
   ) {
-    this.width = Math.min(Deno.consoleSize()?.columns, 150);
+    try {
+      this.width = Math.min(Deno.consoleSize().columns, 150);
+    } catch (_err) {
+      this.width = 150;
+    }
     this.options = {
       types: false,
       hints: true,

--- a/command/help/_help_generator.ts
+++ b/command/help/_help_generator.ts
@@ -162,7 +162,7 @@ export class HelpGenerator {
       ])
         .padding([2, 1, 2])
         .indent(this.indent)
-        .maxTableWidth(this.width - this.indent)
+        .maxWidth(this.width - this.indent)
         .flexShrink([0, 0, 1, 1])
         .maxColWidth([60, 1, 80, 60])
         .toString() +
@@ -228,7 +228,7 @@ export class HelpGenerator {
         ])
           .padding([2, 2, 1, 2])
           .indent(this.indent)
-          .maxTableWidth(this.width - this.indent)
+          .maxWidth(this.width - this.indent)
           .flexShrink([0, 0, 0, 1, 1])
           .maxColWidth([60, 60, 1, 80, 60])
           .toString() +
@@ -245,7 +245,7 @@ export class HelpGenerator {
         ]),
       ])
         .indent(this.indent)
-        .maxTableWidth(this.width - this.indent)
+        .maxWidth(this.width - this.indent)
         .flexShrink([0, 0, 0, 1])
         .maxColWidth([60, 1, 80, 60])
         .padding([2, 1, 2])
@@ -279,7 +279,7 @@ export class HelpGenerator {
           ]),
         ])
           .indent(this.indent)
-          .maxTableWidth(this.width - this.indent)
+          .maxWidth(this.width - this.indent)
           .flexShrink([0, 0, 0, 1])
           .maxColWidth([60, 60, 1, 80])
           .padding([2, 2, 1, 2])
@@ -298,7 +298,7 @@ export class HelpGenerator {
           command.getShortDescription(),
         ]),
       ])
-        .maxTableWidth(this.width - this.indent)
+        .maxWidth(this.width - this.indent)
         .flexShrink([0, 0, 1])
         .maxColWidth([60, 1, 80])
         .padding([2, 1, 2])
@@ -329,7 +329,7 @@ export class HelpGenerator {
       ])
         .padding([2, 2, 1, 2])
         .indent(this.indent)
-        .maxTableWidth(this.width - this.indent)
+        .maxWidth(this.width - this.indent)
         .flexShrink([0, 0, 0, 1, 1])
         .maxColWidth([60, 60, 1, 80, 10])
         .toString() +
@@ -348,7 +348,7 @@ export class HelpGenerator {
       ]))
         .padding(1)
         .indent(this.indent)
-        .maxTableWidth(this.width - this.indent)
+        .maxWidth(this.width - this.indent)
         .flexShrink([0, 1])
         .toString() +
       "\n";

--- a/table/_layout.ts
+++ b/table/_layout.ts
@@ -5,6 +5,9 @@ import { Row, type RowType } from "./row.ts";
 import type { BorderOptions, Table, TableSettings } from "./table.ts";
 import { getUnclosedAnsiRuns, longest, strLength } from "./_utils.ts";
 
+const sum = (numList: Array<number>): number =>
+  numList.reduce((a, b) => a + b, 0);
+
 /** Layout render settings. */
 interface RenderSettings {
   padding: Array<number>;
@@ -89,9 +92,9 @@ export class TableLayout {
     }
 
     /* Try to get the total table width within a maximum */
-    const totalWidth = width.reduce((a, b) => a + b);
+    const totalWidth = sum(width);
     const maxAllowable = this.options.maxTableWidth -
-      padding.filter((x) => x).reduce((a, b) => a + b);
+      sum(padding.filter((x) => x));
     if (totalWidth > maxAllowable && this.options.colRigidity != 1) {
       const rigidity = width.map(
         (_w, i) => (
@@ -100,15 +103,11 @@ export class TableLayout {
             : this.options.colRigidity
         ),
       );
-      const rigidTotal = width.map((w, i) => rigidity[i] >= 1 ? w : 0).reduce(
-        (a, b) => a + b,
-      );
+      const rigidTotal = sum(width.map((w, i) => rigidity[i] >= 1 ? w : 0));
 
       const slack = maxAllowable - rigidTotal;
       if (slack > 0) {
-        const flexTotal = width.map((w, i) => rigidity[i] < 1 ? w : 0).reduce(
-          (a, b) => a + b,
-        );
+        const flexTotal = sum(width.map((w, i) => rigidity[i] < 1 ? w : 0));
         const flexFactor = slack / flexTotal;
         for (let colIndex = 0; colIndex < width.length; colIndex++) {
           if (rigidity[colIndex] < 1) {

--- a/table/_layout.ts
+++ b/table/_layout.ts
@@ -94,7 +94,7 @@ export class TableLayout {
       padding.filter((x) => x).reduce((a, b) => a + b);
     if (totalWidth > maxAllowable && this.options.colRigidity != 1) {
       const rigidity = width.map(
-        (w, i) => (
+        (_w, i) => (
           Array.isArray(this.options.colRigidity)
             ? this.options.colRigidity[i]
             : this.options.colRigidity

--- a/table/_layout.ts
+++ b/table/_layout.ts
@@ -98,11 +98,11 @@ export class TableLayout {
     }
 
     /* Try to get the total table width within a maximum */
-    if (isFinite(this.options.maxTableWidth)) {
+    if (isFinite(this.options.maxWidth)) {
       const totalPadding = hasBorder
         ? sum(padding) * 2 + (columns + 1)
         : sum(padding.slice(0, -1));
-      const maxAllowable = this.options.maxTableWidth - totalPadding;
+      const maxAllowable = this.options.maxWidth - totalPadding;
 
       if (sum(width) > maxAllowable) {
         const flex = width.map((_w, i) =>

--- a/table/_layout.ts
+++ b/table/_layout.ts
@@ -95,22 +95,26 @@ export class TableLayout {
     const totalWidth = sum(width);
     const maxAllowable = this.options.maxTableWidth -
       sum(padding.filter((x) => x));
-    if (totalWidth > maxAllowable && this.options.colRigidity != 1) {
-      const rigidity = width.map(
+    if (totalWidth > maxAllowable && this.options.flexShrink != 0) {
+      const flex = width.map(
         (_w, i) => (
-          Array.isArray(this.options.colRigidity)
-            ? this.options.colRigidity[i]
-            : this.options.colRigidity
+          Array.isArray(this.options.flexShrink)
+            ? this.options.flexShrink[i]
+            : this.options.flexShrink
         ),
       );
-      const rigidTotal = sum(width.map((w, i) => rigidity[i] >= 1 ? w : 0));
+      // Currently treating flexShrink as a boolean, so any non-zero value means
+      // full flexibility. With proper consideration of weights, we might use
+      // multiplication, e.g. `(1 - flex[i]) * w`
+      const rigidTotal = sum(width.map((w, i) => flex[i] === 0 ? w : 0));
 
       const slack = maxAllowable - rigidTotal;
       if (slack > 0) {
-        const flexTotal = sum(width.map((w, i) => rigidity[i] < 1 ? w : 0));
+        // Likewise, this might become something like `flex[i] * w`
+        const flexTotal = sum(width.map((w, i) => flex[i] === 0 ? 0 : w));
         const flexFactor = slack / flexTotal;
         for (let colIndex = 0; colIndex < width.length; colIndex++) {
-          if (rigidity[colIndex] < 1) {
+          if (flex[colIndex] > 0) {
             const column = this.options.columns.at(colIndex);
             const minColWidth: number = column?.getMinWidth() ??
               (Array.isArray(this.options.minColWidth)

--- a/table/_layout.ts
+++ b/table/_layout.ts
@@ -70,20 +70,26 @@ export class TableLayout {
 
     const padding: Array<number> = [];
     const width: Array<number> = [];
+    const minColWidth: Array<number> = [];
+    const maxColWidth: Array<number> = [];
+
     for (let colIndex = 0; colIndex < columns; colIndex++) {
       const column = this.options.columns.at(colIndex);
-      const minColWidth: number = column?.getMinWidth() ??
+      minColWidth[colIndex] = column?.getMinWidth() ??
         (Array.isArray(this.options.minColWidth)
           ? this.options.minColWidth[colIndex]
           : this.options.minColWidth);
 
-      const maxColWidth: number = column?.getMaxWidth() ??
+      maxColWidth[colIndex] = column?.getMaxWidth() ??
         (Array.isArray(this.options.maxColWidth)
           ? this.options.maxColWidth[colIndex]
           : this.options.maxColWidth);
 
-      const colWidth: number = longest(colIndex, rows, maxColWidth);
-      width[colIndex] = Math.min(maxColWidth, Math.max(minColWidth, colWidth));
+      const colWidth: number = longest(colIndex, rows, maxColWidth[colIndex]);
+      width[colIndex] = Math.min(
+        maxColWidth[colIndex],
+        Math.max(minColWidth[colIndex], colWidth),
+      );
 
       padding[colIndex] = column?.getPadding() ??
         (Array.isArray(this.options.padding)
@@ -92,43 +98,58 @@ export class TableLayout {
     }
 
     /* Try to get the total table width within a maximum */
-    const totalWidth = sum(width);
-    const maxAllowable = this.options.maxTableWidth -
-      sum(padding.filter((x) => x));
-    if (totalWidth > maxAllowable && this.options.flexShrink != 0) {
-      const flex = width.map(
-        (_w, i) => (
-          Array.isArray(this.options.flexShrink)
-            ? this.options.flexShrink[i]
-            : this.options.flexShrink
-        ),
-      );
-      // Currently treating flexShrink as a boolean, so any non-zero value means
-      // full flexibility. With proper consideration of weights, we might use
-      // multiplication, e.g. `(1 - flex[i]) * w`
-      const rigidTotal = sum(width.map((w, i) => flex[i] === 0 ? w : 0));
+    if (isFinite(this.options.maxTableWidth)) {
+      const totalPadding = hasBorder
+        ? sum(padding) * 2 + (columns + 1)
+        : sum(padding.slice(0, -1));
+      const maxAllowable = this.options.maxTableWidth - totalPadding;
 
-      const slack = maxAllowable - rigidTotal;
-      if (slack > 0) {
-        // Likewise, this might become something like `flex[i] * w`
-        const flexTotal = sum(width.map((w, i) => flex[i] === 0 ? 0 : w));
-        const flexFactor = slack / flexTotal;
-        for (let colIndex = 0; colIndex < width.length; colIndex++) {
-          if (flex[colIndex] > 0) {
-            const column = this.options.columns.at(colIndex);
-            const minColWidth: number = column?.getMinWidth() ??
-              (Array.isArray(this.options.minColWidth)
-                ? this.options.minColWidth[colIndex]
-                : this.options.minColWidth);
-            const maxColWidth: number = column?.getMaxWidth() ??
-              (Array.isArray(this.options.maxColWidth)
-                ? this.options.maxColWidth[colIndex]
-                : this.options.maxColWidth);
+      if (sum(width) > maxAllowable) {
+        const flex = width.map((_w, i) =>
+          this.options.columns.at(i)?.getFlexShrink() ??
+            (Array.isArray(this.options.flexShrink)
+              ? (this.options.flexShrink[i] ?? 1)
+              : this.options.flexShrink)
+        );
 
-            width[colIndex] = Math.min(
-              maxColWidth,
-              Math.max(minColWidth, Math.floor(width[colIndex] * flexFactor)),
-            );
+        let changed = true;
+        while (changed) {
+          changed = false;
+          if (sum(width) <= maxAllowable) {
+            break;
+          }
+          // Currently treating flexShrink as a boolean, so any non-zero value means
+          // full flexibility. With proper consideration of weights, we might use
+          // multiplication, e.g. `(1 - flex[i]) * w`
+          const rigidTotal = sum(
+            width.map((w, i) => flex[i] === 0 || w <= minColWidth[i] ? w : 0),
+          );
+
+          const slack = maxAllowable - rigidTotal;
+          if (slack <= 0) {
+            break;
+          }
+          const flexTotal = sum(
+            width.map((w, i) => flex[i] > 0 && w > minColWidth[i] ? w : 0),
+          );
+          if (flexTotal === 0) {
+            break;
+          }
+          const flexFactor = slack / flexTotal;
+          for (let colIndex = 0; colIndex < width.length; colIndex++) {
+            if (
+              flex[colIndex] > 0 && width[colIndex] > minColWidth[colIndex]
+            ) {
+              // NOTE: Math.floor can leave up to N characters of unused space.
+              const target = Math.max(
+                minColWidth[colIndex],
+                Math.floor(width[colIndex] * flexFactor),
+              );
+              if (target !== width[colIndex]) {
+                width[colIndex] = target;
+                changed = true;
+              }
+            }
           }
         }
       }

--- a/table/column.ts
+++ b/table/column.ts
@@ -12,7 +12,7 @@ export interface ColumnOptions {
   maxWidth?: number;
   /** Set cell padding. */
   padding?: number;
-  /** Set column flexibility to shrink. 1 is enabled, 0 disabled. */
+  /** Set column flex-shrink factor (0 = rigid, 1 = flexible). */
   flexShrink?: number;
 }
 
@@ -81,6 +81,12 @@ export class Column {
     return this;
   }
 
+  /** Set column flex-shrink factor (0 = rigid, 1 = flexible). */
+  flexShrink(factor = 1): this {
+    this.opts.flexShrink = factor;
+    return this;
+  }
+
   /** Get min column width. */
   getMinWidth(): number | undefined {
     return this.opts.minWidth;
@@ -106,7 +112,7 @@ export class Column {
     return this.opts.align;
   }
 
-  /** Get flex shrink. */
+  /** Get column flex-shrink factor. */
   getFlexShrink(): number | undefined {
     return this.opts.flexShrink;
   }

--- a/table/column.ts
+++ b/table/column.ts
@@ -12,6 +12,8 @@ export interface ColumnOptions {
   maxWidth?: number;
   /** Set cell padding. */
   padding?: number;
+  /** Set column flexibility to shrink. 1 is enabled, 0 disabled. */
+  flexShrink?: number;
 }
 
 /**
@@ -102,5 +104,10 @@ export class Column {
   /** Get column alignment. */
   getAlign(): Direction | undefined {
     return this.opts.align;
+  }
+
+  /** Get flex shrink. */
+  getFlexShrink(): number | undefined {
+    return this.opts.flexShrink;
   }
 }

--- a/table/table.ts
+++ b/table/table.ts
@@ -17,6 +17,10 @@ export interface TableSettings {
   minColWidth: number | Array<number>;
   /** Set max column width. */
   maxColWidth: number | Array<number>;
+  /** Set max table width. */
+  maxTableWidth: number;
+  /** Set column rigidity */
+  colRigidity: number | Array<number>;
   /** Set cell padding. */
   padding: number | Array<number>;
   /** Set table characters. */
@@ -57,6 +61,8 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
     maxColWidth: Infinity,
     minColWidth: 0,
     padding: 1,
+    maxTableWidth: Infinity,
+    colRigidity: 1,
     chars: { ...Table._chars },
     columns: [],
   };
@@ -218,6 +224,32 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
   public minColWidth(width: number | Array<number>, override = true): this {
     if (override || typeof this.options.minColWidth === "undefined") {
       this.options.minColWidth = width;
+    }
+    return this;
+  }
+
+  /**
+   * Set max table width
+   *
+   * @param width     Max table width.
+   * @param override  Override existing value.
+   */
+  public maxTableWidth(width: number, override = true): this {
+    if (override || typeof this.options.maxTableWidth === "undefined") {
+      this.options.maxTableWidth = width;
+    }
+    return this;
+  }
+
+  /**
+   * Set column rigidity
+   *
+   * @param rigidity  Column rigidity.
+   * @param override  Override existing value.
+   */
+  public colRigidity(rigidity: number | Array<number>, override = true): this {
+    if (override || typeof this.options.colRigidity === "undefined") {
+      this.options.colRigidity = rigidity;
     }
     return this;
   }

--- a/table/table.ts
+++ b/table/table.ts
@@ -247,7 +247,10 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
    * @param flexShrink  Per-column shrink factor, or a single value for all columns.
    * @param override    Override existing value.
    */
-  public flexShrink(flexShrink: number | Array<number> = 1, override = true): this {
+  public flexShrink(
+    flexShrink: number | Array<number> = 1,
+    override = true,
+  ): this {
     if (override || typeof this.options.flexShrink === "undefined") {
       this.options.flexShrink = flexShrink;
     }

--- a/table/table.ts
+++ b/table/table.ts
@@ -19,8 +19,8 @@ export interface TableSettings {
   maxColWidth: number | Array<number>;
   /** Set max table width. */
   maxTableWidth: number;
-  /** Set column rigidity */
-  colRigidity: number | Array<number>;
+  /** Set column flexibility to shrink. 1 is enabled, 0 disabled. */
+  flexShrink: number | Array<number>;
   /** Set cell padding. */
   padding: number | Array<number>;
   /** Set table characters. */
@@ -62,7 +62,7 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
     minColWidth: 0,
     padding: 1,
     maxTableWidth: Infinity,
-    colRigidity: 1,
+    flexShrink: 0,
     chars: { ...Table._chars },
     columns: [],
   };
@@ -247,9 +247,9 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
    * @param rigidity  Column rigidity.
    * @param override  Override existing value.
    */
-  public colRigidity(rigidity: number | Array<number>, override = true): this {
-    if (override || typeof this.options.colRigidity === "undefined") {
-      this.options.colRigidity = rigidity;
+  public flexShrink(rigidity: number | Array<number>, override = true): this {
+    if (override || typeof this.options.flexShrink === "undefined") {
+      this.options.flexShrink = rigidity;
     }
     return this;
   }

--- a/table/table.ts
+++ b/table/table.ts
@@ -18,7 +18,7 @@ export interface TableSettings {
   /** Set max column width. */
   maxColWidth: number | Array<number>;
   /** Set max table width. */
-  maxTableWidth: number;
+  maxWidth: number;
   /** Set column flex-shrink factor (0 = rigid, 1 = flexible). */
   flexShrink: number | Array<number>;
   /** Set cell padding. */
@@ -61,7 +61,7 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
     maxColWidth: Infinity,
     minColWidth: 0,
     padding: 1,
-    maxTableWidth: Infinity,
+    maxWidth: Infinity,
     flexShrink: 1,
     chars: { ...Table._chars },
     columns: [],
@@ -234,9 +234,9 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
    * @param width     Max table width.
    * @param override  Override existing value.
    */
-  public maxTableWidth(width: number, override = true): this {
-    if (override || typeof this.options.maxTableWidth === "undefined") {
-      this.options.maxTableWidth = width;
+  public maxWidth(width: number, override = true): this {
+    if (override || typeof this.options.maxWidth === "undefined") {
+      this.options.maxWidth = width;
     }
     return this;
   }

--- a/table/table.ts
+++ b/table/table.ts
@@ -19,7 +19,7 @@ export interface TableSettings {
   maxColWidth: number | Array<number>;
   /** Set max table width. */
   maxTableWidth: number;
-  /** Set column flexibility to shrink. 1 is enabled, 0 disabled. */
+  /** Set column flex-shrink factor (0 = rigid, 1 = flexible). */
   flexShrink: number | Array<number>;
   /** Set cell padding. */
   padding: number | Array<number>;
@@ -62,7 +62,7 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
     minColWidth: 0,
     padding: 1,
     maxTableWidth: Infinity,
-    flexShrink: 0,
+    flexShrink: 1,
     chars: { ...Table._chars },
     columns: [],
   };
@@ -242,14 +242,14 @@ export class Table<TRow extends RowType = RowType> extends Array<TRow> {
   }
 
   /**
-   * Set column rigidity
+   * Set column flex-shrink factor (0 = rigid, 1 = flexible).
    *
-   * @param rigidity  Column rigidity.
-   * @param override  Override existing value.
+   * @param flexShrink  Per-column shrink factor, or a single value for all columns.
+   * @param override    Override existing value.
    */
-  public flexShrink(rigidity: number | Array<number>, override = true): this {
+  public flexShrink(flexShrink: number | Array<number> = 1, override = true): this {
     if (override || typeof this.options.flexShrink === "undefined") {
-      this.options.flexShrink = rigidity;
+      this.options.flexShrink = flexShrink;
     }
     return this;
   }

--- a/table/test/table_test.ts
+++ b/table/test/table_test.ts
@@ -755,13 +755,13 @@ cell1               cell2                 At vero eos et
   );
 });
 
-test("should shrink all columns proportionally when maxTableWidth is set", () => {
+test("should shrink all columns proportionally when maxWidth is set", () => {
   assertEquals(
     Table.from([
       ["JavaScript", "TypeScript"],
     ])
       .padding(1)
-      .maxTableWidth(14)
+      .maxWidth(14)
       .toString(),
     `\
 JavaSc TypeSc
@@ -775,7 +775,7 @@ test("should keep rigid columns unchanged when flexShrink is set per column", ()
       ["--env", "sets the runtime environment"],
     ])
       .padding(1)
-      .maxTableWidth(22)
+      .maxWidth(22)
       .flexShrink([0, 1])
       .toString(),
     `\
@@ -790,7 +790,7 @@ test("should redistribute slack to other flex columns when minColWidth clamps on
       ["--config", "path/to/config.json"],
     ])
       .padding(1)
-      .maxTableWidth(18)
+      .maxWidth(18)
       .minColWidth([7, 0])
       .toString(),
     `\
@@ -805,7 +805,7 @@ test("should respect Column.flexShrink when set via Column API", () => {
       ["--output", "production"],
     ])
       .padding(1)
-      .maxTableWidth(15)
+      .maxWidth(15)
       .column(0, new Column().flexShrink(0))
       .toString(),
     `\

--- a/table/test/table_test.ts
+++ b/table/test/table_test.ts
@@ -2,6 +2,7 @@ import { test } from "@cliffy/internal/testing/test";
 import { Table } from "../table.ts";
 import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
 import { Row } from "../row.ts";
+import { Column } from "../column.ts";
 
 test("simple table", () => {
   assertEquals(
@@ -751,5 +752,64 @@ cell1               cell2                 At vero eos et
                                           justo duo     
                                           dolores et ea 
                                           rebum.        `.slice(1),
+  );
+});
+
+test("should shrink all columns proportionally when maxTableWidth is set", () => {
+  assertEquals(
+    Table.from([
+      ["JavaScript", "TypeScript"],
+    ])
+      .padding(1)
+      .maxTableWidth(14)
+      .toString(),
+    `\
+JavaSc TypeSc
+ript   ript  `,
+  );
+});
+
+test("should keep rigid columns unchanged when flexShrink is set per column", () => {
+  assertEquals(
+    Table.from([
+      ["--env", "sets the runtime environment"],
+    ])
+      .padding(1)
+      .maxTableWidth(22)
+      .flexShrink([0, 1])
+      .toString(),
+    `\
+--env sets the runtime
+      environment     `,
+  );
+});
+
+test("should redistribute slack to other flex columns when minColWidth clamps one", () => {
+  assertEquals(
+    Table.from([
+      ["--config", "path/to/config.json"],
+    ])
+      .padding(1)
+      .maxTableWidth(18)
+      .minColWidth([7, 0])
+      .toString(),
+    `\
+--confi path/to/co
+g       nfig.json `,
+  );
+});
+
+test("should respect Column.flexShrink when set via Column API", () => {
+  assertEquals(
+    Table.from([
+      ["--output", "production"],
+    ])
+      .padding(1)
+      .maxTableWidth(15)
+      .column(0, new Column().flexShrink(0))
+      .toString(),
+    `\
+--output produc
+         tion  `,
   );
 });


### PR DESCRIPTION
This PR adds `maxTableWidth` and `colRigidity` options to `TableSettings`, allowing the table renderer to target a particular maximum width. `colRigidity` is a parameter where `1` indicates that the column width should not be reduced, and `0` that it can be adjusted arbitrarily. I made it a number instead of a bool, since it seems plausible to allow for a `0.5` to be reduced by half the amount of a `0`, but I only implemented `0` and `1`.

I then use this to update the help text generation, which is constrained to use the terminal width as the maximum width. I make the first columns rigid, as the descriptions and types are more likely to take up space and more tolerant to line breaks.

I hope this is reasonable. It dramatically improves the help text for my tool.

<details><summary>Before (regardless of terminal width):</summary>

```
❯ deno run -A jsr:@bids/validator --help

Usage:   bids-validator <dataset_directory>
Version: 1.14.13

Description:

  This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about
  Brain Imaging Data Structure visit http://bids.neuroimaging.io

Options:

  -h, --help                              - Show this help.
  -V, --version                           - Show the version number for this program.
  --json                                  - Output machine readable JSON
  -s, --schema           <URL-or-tag>     - Specify a schema version to use for validation
  -c, --config           <file>           - Path to a JSON configuration file
  -v, --verbose                           - Log more extensive information about issues
  --ignoreWarnings                        - Disregard non-critical issues
  --ignoreNiftiHeaders                    - Disregard NIfTI header content during validation
  --debug                <level>          - Enable debug output                                                             (Default: "ERROR", Values: "NOTSET", "DEBUG", "INFO",
                                                                                                                            "WARN", "ERROR", "CRITICAL")
  --filenameMode                          - Enable filename checks for newline separated filenames read from stdin
  --blacklistModalities  <modalities...>  - Array of modalities to error on if detected.                                    (Default: [], Values: "MRI", "PET", "MEG", "EEG", "iEEG",
                                                                                                                            "Microscopy", "NIRS", "MRS")
  -r, --recursive                         - Validate datasets found in derivatives directories in addition to root dataset
  -o, --outfile          <file>           - File to write validation results to.
  --color, --no-color    [color]          - Enable/disable color output (defaults to detected support)                      (Default: true)
```

</details>
<details><summary>After (88 columns)</summary>

```
❯ deno run -A ~/Projects/bids/bids-validator/bids-validator/src/bids-validator.ts --help

Usage:   bids-validator <dataset_directory>
Version: v1.14.15-dev.0-11-g8f3519b3

Description:

  This tool checks if a dataset in a given directory is compatible with the Brain
  Imaging Data Structure specification. To learn more about Brain Imaging Data
  Structure visit http://bids.neuroimaging.io

Options:

  -h, --help                              - Show this help.
  -V, --version                           - Show the version number
                                            for this program.
  --json                                  - Output machine readable
                                            JSON
  -s, --schema           <URL-or-tag>     - Specify a schema version
                                            to use for validation
  -c, --config           <file>           - Path to a JSON
                                            configuration file
  -v, --verbose                           - Log more extensive
                                            information about issues
  --ignoreWarnings                        - Disregard non-critical
                                            issues
  --ignoreNiftiHeaders                    - Disregard NIfTI header
                                            content during
                                            validation
  --debug                <level>          - Enable debug output       (Default:
                                                                      "ERROR", Values:
                                                                      "NOTSET",
                                                                      "DEBUG", "INFO",
                                                                      "WARN", "ERROR",
                                                                      "CRITICAL")
  --filenameMode                          - Enable filename checks
                                            for newline separated
                                            filenames read from
                                            stdin
  --blacklistModalities  <modalities...>  - Array of modalities to    (Default: [],
                                            error on if detected.     Values: "MRI",
                                                                      "PET", "MEG",
                                                                      "EEG", "iEEG",
                                                                      "Microscopy",
                                                                      "NIRS", "MRS")
  -r, --recursive                         - Validate datasets found
                                            in derivatives
                                            directories in addition
                                            to root dataset
  -o, --outfile          <file>           - File to write validation
                                            results to.
  --color, --no-color    [color]          - Enable/disable color      (Default: true)
                                            output (defaults to
                                            detected support)
```

</details>

<details><summary>142 columns</summary>

```
❯ deno run -A ~/Projects/bids/bids-validator/bids-validator/src/bids-validator.ts --help

Usage:   bids-validator <dataset_directory>
Version: v1.14.15-dev.0-11-g8f3519b3

Description:

  This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about
  Brain Imaging Data Structure visit http://bids.neuroimaging.io

Options:

  -h, --help                              - Show this help.
  -V, --version                           - Show the version number for this program.
  --json                                  - Output machine readable JSON
  -s, --schema           <URL-or-tag>     - Specify a schema version to use for validation
  -c, --config           <file>           - Path to a JSON configuration file
  -v, --verbose                           - Log more extensive information about issues
  --ignoreWarnings                        - Disregard non-critical issues
  --ignoreNiftiHeaders                    - Disregard NIfTI header content during validation
  --debug                <level>          - Enable debug output                                      (Default: "ERROR", Values: "NOTSET",
                                                                                                     "DEBUG", "INFO", "WARN", "ERROR",
                                                                                                     "CRITICAL")
  --filenameMode                          - Enable filename checks for newline separated filenames
                                            read from stdin
  --blacklistModalities  <modalities...>  - Array of modalities to error on if detected.             (Default: [], Values: "MRI", "PET",
                                                                                                     "MEG", "EEG", "iEEG", "Microscopy",
                                                                                                     "NIRS", "MRS")
  -r, --recursive                         - Validate datasets found in derivatives directories in
                                            addition to root dataset
  -o, --outfile          <file>           - File to write validation results to.
  --color, --no-color    [color]          - Enable/disable color output (defaults to detected        (Default: true)
                                            support)
```

</details>