### PR TITLE
make work with dnt

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -2051,7 +2051,7 @@ export class Command<
     names: readonly string[],
   ): Promise<{ name: string; value: string } | undefined> {
     for (const name of names) {
-        // dnt-shim-ignore
+      // dnt-shim-ignore
       const status = await (globalThis as any).Deno?.permissions.query({
         name: "env",
         variable: name,

--- a/command/command.ts
+++ b/command/command.ts
@@ -2051,6 +2051,7 @@ export class Command<
     names: readonly string[],
   ): Promise<{ name: string; value: string } | undefined> {
     for (const name of names) {
+        // dnt-shim-ignore
       const status = await (globalThis as any).Deno?.permissions.query({
         name: "env",
         variable: name,

--- a/command/upgrade/get_runtime.ts
+++ b/command/upgrade/get_runtime.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 import type { RuntimeName } from "@cliffy/internal/runtime/runtime-name";
 import type { Runtime } from "./runtime.ts";
 
@@ -9,7 +11,7 @@ export interface GetRuntimeResult {
 
 /** Get runtime handler for current runtime. */
 export async function getRuntime(): Promise<GetRuntimeResult> {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno?.version?.deno) {

--- a/command/upgrade/get_runtime.ts
+++ b/command/upgrade/get_runtime.ts
@@ -9,7 +9,7 @@ export interface GetRuntimeResult {
 
 /** Get runtime handler for current runtime. */
 export async function getRuntime(): Promise<GetRuntimeResult> {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno?.version?.deno) {

--- a/command/upgrade/runtime/bun_runtime.ts
+++ b/command/upgrade/runtime/bun_runtime.ts
@@ -8,9 +8,9 @@ export class BunRuntime extends NodeRuntime {
     isJsr: boolean,
     logger?: Logger,
   ): Promise<void> {
-    // deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore deno-lint-ignore no-explicit-any
     const Bun = (globalThis as any).Bun;
-    // deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore deno-lint-ignore no-explicit-any
     const process = (globalThis as any).process;
 
     cmdArgs = isJsr

--- a/command/upgrade/runtime/bun_runtime.ts
+++ b/command/upgrade/runtime/bun_runtime.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 import { dim } from "@std/fmt/colors";
 import type { Logger } from "../logger.ts";
 import { NodeRuntime } from "./node_runtime.ts";
@@ -8,9 +10,9 @@ export class BunRuntime extends NodeRuntime {
     isJsr: boolean,
     logger?: Logger,
   ): Promise<void> {
-    // dnt-shim-ignore deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore
     const Bun = (globalThis as any).Bun;
-    // dnt-shim-ignore deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore
     const process = (globalThis as any).process;
 
     cmdArgs = isJsr

--- a/command/upgrade/spinner.ts
+++ b/command/upgrade/spinner.ts
@@ -197,7 +197,7 @@ export class Spinner {
    * ```
    */
   start() {
-    // deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore deno-lint-ignore no-explicit-any
     if (this.#active || (globalThis as any).Deno?.stdout.writable.locked) {
       return;
     }

--- a/command/upgrade/spinner.ts
+++ b/command/upgrade/spinner.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { getNoColor } from "@cliffy/internal/runtime/no-color";
@@ -197,7 +199,7 @@ export class Spinner {
    * ```
    */
   start() {
-    // dnt-shim-ignore deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore
     if (this.#active || (globalThis as any).Deno?.stdout.writable.locked) {
       return;
     }

--- a/internal/runtime/delete_env.ts
+++ b/internal/runtime/delete_env.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Delete environment variable.
  *
@@ -5,7 +7,7 @@
  * @param name The name of the environment variable.
  */
 export function deleteEnv(name: string): string | undefined {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/delete_env.ts
+++ b/internal/runtime/delete_env.ts
@@ -5,7 +5,7 @@
  * @param name The name of the environment variable.
  */
 export function deleteEnv(name: string): string | undefined {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/exit.ts
+++ b/internal/runtime/exit.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Exit the current process with optional exit code.
  *
@@ -5,7 +7,7 @@
  * @param code The exit code.
  */
 export function exit(code: number): never {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
   const exit: (code: number) => never = Deno?.exit ?? process?.exit;
 

--- a/internal/runtime/exit.ts
+++ b/internal/runtime/exit.ts
@@ -5,7 +5,7 @@
  * @param code The exit code.
  */
 export function exit(code: number): never {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
   const exit: (code: number) => never = Deno?.exit ?? process?.exit;
 

--- a/internal/runtime/get_args.ts
+++ b/internal/runtime/get_args.ts
@@ -1,10 +1,12 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Get script arguments.
  *
  * @internal
  */
 export function getArgs(): Array<string> {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   return Deno?.args ?? process?.argv.slice(2) ?? [];

--- a/internal/runtime/get_args.ts
+++ b/internal/runtime/get_args.ts
@@ -4,7 +4,7 @@
  * @internal
  */
 export function getArgs(): Array<string> {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   return Deno?.args ?? process?.argv.slice(2) ?? [];

--- a/internal/runtime/get_columns.ts
+++ b/internal/runtime/get_columns.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Returns the width of the console window.
  *
@@ -5,7 +7,7 @@
  */
 export function getColumns(): number | null {
   try {
-    // dnt-shim-ignore deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore
     const { Deno, process } = globalThis as any;
 
     // Catch error in none tty mode: Inappropriate ioctl for device (os error 25)

--- a/internal/runtime/get_columns.ts
+++ b/internal/runtime/get_columns.ts
@@ -5,7 +5,7 @@
  */
 export function getColumns(): number | null {
   try {
-    // deno-lint-ignore no-explicit-any
+    // dnt-shim-ignore deno-lint-ignore no-explicit-any
     const { Deno, process } = globalThis as any;
 
     // Catch error in none tty mode: Inappropriate ioctl for device (os error 25)

--- a/internal/runtime/get_env.ts
+++ b/internal/runtime/get_env.ts
@@ -5,7 +5,7 @@
  * @param name The name of the environment variable.
  */
 export function getEnv(name: string): string | undefined {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/get_env.ts
+++ b/internal/runtime/get_env.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Get environment variable.
  *
@@ -5,7 +7,7 @@
  * @param name The name of the environment variable.
  */
 export function getEnv(name: string): string | undefined {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/get_os.ts
+++ b/internal/runtime/get_os.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Get operating system name.
  *
@@ -16,7 +18,7 @@ export function getOs():
   | "openbsd"
   | "sunos"
   | "win32" {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/get_os.ts
+++ b/internal/runtime/get_os.ts
@@ -16,7 +16,7 @@ export function getOs():
   | "openbsd"
   | "sunos"
   | "win32" {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/inspect.ts
+++ b/internal/runtime/inspect.ts
@@ -4,7 +4,7 @@
  * @internal
  */
 export function inspect(value: unknown, colors: boolean): string {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno } = globalThis as any;
 
   return Deno?.inspect(

--- a/internal/runtime/inspect.ts
+++ b/internal/runtime/inspect.ts
@@ -1,10 +1,12 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Inspect values.
  *
  * @internal
  */
 export function inspect(value: unknown, colors: boolean): string {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno } = globalThis as any;
 
   return Deno?.inspect(

--- a/internal/runtime/is_terminal.ts
+++ b/internal/runtime/is_terminal.ts
@@ -1,10 +1,12 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Checks if current process is a tty.
  *
  * @internal
  */
 export function isTerminal(): boolean {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/is_terminal.ts
+++ b/internal/runtime/is_terminal.ts
@@ -4,7 +4,7 @@
  * @internal
  */
 export function isTerminal(): boolean {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/no_color.ts
+++ b/internal/runtime/no_color.ts
@@ -1,10 +1,12 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Checks if colors are enabled.
  *
  * @internal
  */
 export function getNoColor(): boolean {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/no_color.ts
+++ b/internal/runtime/no_color.ts
@@ -4,7 +4,7 @@
  * @internal
  */
 export function getNoColor(): boolean {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/read.ts
+++ b/internal/runtime/read.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Read from stdin.
  *
@@ -5,7 +7,7 @@
  * @param data Uint8Array to store the data.
  */
 export async function read(data: Uint8Array): Promise<number | null> {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, Bun, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/read.ts
+++ b/internal/runtime/read.ts
@@ -5,7 +5,7 @@
  * @param data Uint8Array to store the data.
  */
 export async function read(data: Uint8Array): Promise<number | null> {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, Bun, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/read_dir.ts
+++ b/internal/runtime/read_dir.ts
@@ -5,7 +5,7 @@
  * @param path Path to the directory.
  */
 export async function readDir(path: string): Promise<Array<{ name: string }>> {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno } = globalThis as any;
   path ||= ".";
 

--- a/internal/runtime/read_dir.ts
+++ b/internal/runtime/read_dir.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Get directory list.
  *
@@ -5,7 +7,7 @@
  * @param path Path to the directory.
  */
 export async function readDir(path: string): Promise<Array<{ name: string }>> {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno } = globalThis as any;
   path ||= ".";
 

--- a/internal/runtime/read_sync.ts
+++ b/internal/runtime/read_sync.ts
@@ -1,4 +1,6 @@
-// dnt-shim-ignore deno-lint-ignore no-explicit-any
+// deno-lint-ignore-file no-explicit-any
+
+// dnt-shim-ignore
 const { Deno, process, Buffer } = globalThis as any;
 const { readSync: readSyncNode } = process
   ? await import("node:fs")

--- a/internal/runtime/read_sync.ts
+++ b/internal/runtime/read_sync.ts
@@ -1,4 +1,4 @@
-// deno-lint-ignore no-explicit-any
+// dnt-shim-ignore deno-lint-ignore no-explicit-any
 const { Deno, process, Buffer } = globalThis as any;
 const { readSync: readSyncNode } = process
   ? await import("node:fs")

--- a/internal/runtime/set_env.ts
+++ b/internal/runtime/set_env.ts
@@ -6,7 +6,7 @@
  * @param value The value of the environment variable.
  */
 export function setEnv(name: string, value: string): void {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/set_env.ts
+++ b/internal/runtime/set_env.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Set environment variable.
  *
@@ -6,7 +8,7 @@
  * @param value The value of the environment variable.
  */
 export function setEnv(name: string, value: string): void {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/set_raw.ts
+++ b/internal/runtime/set_raw.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Set raw mode on stdin.
  *
@@ -9,7 +11,7 @@ export function setRaw(
   mode: boolean,
   { cbreak }: { cbreak?: boolean } = {},
 ): void {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/set_raw.ts
+++ b/internal/runtime/set_raw.ts
@@ -9,7 +9,7 @@ export function setRaw(
   mode: boolean,
   { cbreak }: { cbreak?: boolean } = {},
 ): void {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/stat.ts
+++ b/internal/runtime/stat.ts
@@ -5,7 +5,7 @@
  * @param input Path to the file.
  */
 export async function stat(input: string): Promise<{ isDirectory: boolean }> {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/stat.ts
+++ b/internal/runtime/stat.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Get file info.
  *
@@ -5,7 +7,7 @@
  * @param input Path to the file.
  */
 export async function stat(input: string): Promise<{ isDirectory: boolean }> {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/write_sync.ts
+++ b/internal/runtime/write_sync.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 /**
  * Write data to stdout.
  *
@@ -5,7 +7,7 @@
  * @param data Data to write to stdout.
  */
 export function writeSync(data: Uint8Array): number {
-  // dnt-shim-ignore deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/internal/runtime/write_sync.ts
+++ b/internal/runtime/write_sync.ts
@@ -5,7 +5,7 @@
  * @param data Data to write to stdout.
  */
 export function writeSync(data: Uint8Array): number {
-  // deno-lint-ignore no-explicit-any
+  // dnt-shim-ignore deno-lint-ignore no-explicit-any
   const { Deno, process } = globalThis as any;
 
   if (Deno) {

--- a/prompt/_generic_suggestions.ts
+++ b/prompt/_generic_suggestions.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-explicit-any
+
 import type { KeyCode } from "@cliffy/keycode";
 import {
   bold,
@@ -136,7 +138,7 @@ export abstract class GenericSuggestions<TValue, TRawValue>
     // Keep support for deno < 1.10.
     if (this.settings.id && "localStorage" in window) {
       try {
-        // dnt-shim-ignore deno-lint-ignore no-explicit-any
+        // dnt-shim-ignore
         return (window as any).localStorage;
       } catch (_) {
         // Ignore error if --location is not set.
@@ -171,7 +173,7 @@ export abstract class GenericSuggestions<TValue, TRawValue>
 
   protected override async render(): Promise<void> {
     if (this.settings.files && this.#hasReadPermissions === undefined) {
-      // dnt-shim-ignore deno-lint-ignore no-explicit-any
+      // dnt-shim-ignore
       const status = await (globalThis as any).Deno?.permissions.request({
         name: "read",
       });

--- a/prompt/_generic_suggestions.ts
+++ b/prompt/_generic_suggestions.ts
@@ -136,7 +136,7 @@ export abstract class GenericSuggestions<TValue, TRawValue>
     // Keep support for deno < 1.10.
     if (this.settings.id && "localStorage" in window) {
       try {
-        // deno-lint-ignore no-explicit-any
+        // dnt-shim-ignore deno-lint-ignore no-explicit-any
         return (window as any).localStorage;
       } catch (_) {
         // Ignore error if --location is not set.
@@ -171,7 +171,7 @@ export abstract class GenericSuggestions<TValue, TRawValue>
 
   protected override async render(): Promise<void> {
     if (this.settings.files && this.#hasReadPermissions === undefined) {
-      // deno-lint-ignore no-explicit-any
+      // dnt-shim-ignore dnt-shim-ignore deno-lint-ignore no-explicit-any
       const status = await (globalThis as any).Deno?.permissions.request({
         name: "read",
       });

--- a/prompt/_generic_suggestions.ts
+++ b/prompt/_generic_suggestions.ts
@@ -171,7 +171,7 @@ export abstract class GenericSuggestions<TValue, TRawValue>
 
   protected override async render(): Promise<void> {
     if (this.settings.files && this.#hasReadPermissions === undefined) {
-      // dnt-shim-ignore dnt-shim-ignore deno-lint-ignore no-explicit-any
+      // dnt-shim-ignore deno-lint-ignore no-explicit-any
       const status = await (globalThis as any).Deno?.permissions.request({
         name: "read",
       });


### PR DESCRIPTION
@c4spar it's impossible to combine deno-lint-ignore with dnt-shim-ignore directive so had to put deno-lint-ignore at the very top

This allows projects wrote in deno-cliffy to be made node compatible using the dnt tool