### PR TITLE
fix(command): global options don't handle `=` correctly if passed before subcommand

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -1728,7 +1728,7 @@ export class Command<
 
         if (!subCommand) {
           // Only pre parse globals if first arg ist a global option.
-          const optionName = ctx.unknown[0].replace(/^-+/, "");
+          const optionName = ctx.unknown[0].replace(/^-+/, "").split("=")[0];
           const option = this.getOption(optionName, true);
 
           if (option?.global) {

--- a/command/test/option/global_test.ts
+++ b/command/test/option/global_test.ts
@@ -88,6 +88,15 @@ test("[command] should parse global options before sub commands", async () => {
   assertEquals(args, []);
 });
 
+test("[command] should parse global options before sub commands with equal sign", async () => {
+  const { options, args } = await cmd().parse(
+    ["-g=foo", "cmd1", "-G", "bar", "cmd2", "-o", "baz"],
+  );
+
+  assertEquals(options, { global: "FOO", global2: "bar", global3: "baz" });
+  assertEquals(args, []);
+});
+
 test("[command] should collect global options before sub commands", async () => {
   const { options, args } = await new Command()
     .noExit()


### PR DESCRIPTION
fix #796 