### PR TITLE
feat(completions): export function to generate completions

### DIFF
--- a/command/completions/generate.ts
+++ b/command/completions/generate.ts
@@ -1,0 +1,24 @@
+import type { Command } from "../command.ts";
+import { BashCompletionsGenerator } from "./_bash_completions_generator.ts";
+import { FishCompletionsGenerator } from "./_fish_completions_generator.ts";
+import { ZshCompletionsGenerator } from "./_zsh_completions_generator.ts";
+
+/**
+ * Generates shell completions script
+ */
+export function generateCompletions(
+  shell: "bash" | "fish" | "zsh",
+  name: string,
+  cmd: Command,
+): string {
+  switch (shell) {
+    case "bash":
+      return BashCompletionsGenerator.generate(name, cmd);
+    case "zsh":
+      return ZshCompletionsGenerator.generate(name, cmd);
+    case "fish":
+      return FishCompletionsGenerator.generate(name, cmd);
+    default:
+      throw new Error(`Unsupported shell: ${shell}`);
+  }
+}

--- a/command/completions/mod.ts
+++ b/command/completions/mod.ts
@@ -2,3 +2,4 @@ export { BashCompletionsCommand } from "./bash.ts";
 export { FishCompletionsCommand } from "./fish.ts";
 export { ZshCompletionsCommand } from "./zsh.ts";
 export { CompletionsCommand } from "./completions_command.ts";
+export { generateCompletions } from "./generate.ts";


### PR DESCRIPTION
We're building an internal CLI tool in which we'll be able to have a command that installs the shell completions (not just generate them). Currently, to implement them, we have to run the currently exposed command, put the output in the file, then move the file in our own action.

We'd rather have the means to get the generated completions script in JS and write it to the proper file directly. To achieve this, we need access to the underlying generation implementation.

Thus, the PR exports a function `generationCompletions`. I elected not to export the generators themselves. You probably made them private for a reason. Having them part of the public API would be constraining. The function provides a level of indirection that lets you change the implementations in any way you like.

