### PR TITLE
Revert "fix(internal): Use Bun.stdin when using Bun to prevent proces…

### DIFF
--- a/internal/runtime/read.ts
+++ b/internal/runtime/read.ts
@@ -8,7 +8,7 @@
  */
 export function read(data: Uint8Array): Promise<number | null> {
   // dnt-shim-ignore
-  const { Deno, Bun, process } = globalThis as any;
+  const { Deno, process } = globalThis as any;
 
   if (Deno) {
     return Deno.stdin.read(data);


### PR DESCRIPTION
This reverts commit db5ae3061e6dcb43ba681eacadab9d7866cbde24.

This is no longer an issue within bun
https://bun.com/blog/bun-v1.2.21#node-js-compatibility-improvements https://bun.com/blog/bun-v1.2.23#node-js-compatibility-improvements https://bun.com/blog/bun-v1.3#node-js-compatibility

The current implementation breaks on bun 1.3.x


See: https://github.com/JarekToro/cliffy-bun-prompt-bug-