### PR TITLE
feat(command): print help by default for container commands if no arguments are provided

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -942,16 +942,14 @@ export class Command<
       | HelpOptions & CustomHelpOptions,
     customHelpOptions?: CustomHelpOptions,
   ): this {
-    if (typeof help === "object") {
+    if (typeof help === "string") {
+      this.cmd.settings.help = () => help;
+    } else if (typeof help === "function") {
+      this.cmd.settings.help = help;
+    } else {
       customHelpOptions = help;
       this.cmd.settings.help = (cmd: Command, options: HelpOptions): string =>
         HelpGenerator.generate(cmd, { ...help, ...options });
-    } else {
-      if (typeof help === "string") {
-        this.cmd.settings.help = () => help;
-      } else if (typeof help === "function") {
-        this.cmd.settings.help = help;
-      }
     }
 
     if (customHelpOptions?.auto) {

--- a/command/command.ts
+++ b/command/command.ts
@@ -951,10 +951,7 @@ export class Command<
       this.cmd.settings.help = (cmd: Command, options: HelpOptions): string =>
         HelpGenerator.generate(cmd, { ...help, ...options });
     }
-
-    if (customHelpOptions?.auto) {
-      this.cmd.settings.autoHelp = true;
-    }
+    this.cmd.settings.autoHelp = customHelpOptions?.auto;
 
     return this;
   }
@@ -2410,7 +2407,7 @@ export class Command<
     if (
       this.settings.commands.size && !ctx.unknown.length &&
       !ctx.parsedFlags.length && !this.settings.actionHandler &&
-      !this.settings.allowEmpty && this.isAutoHelpEnabled()
+      this.isAutoHelpEnabled()
     ) {
       this.showHelp();
       this.exit();

--- a/command/command.ts
+++ b/command/command.ts
@@ -125,6 +125,7 @@ interface CommandSettings {
   commands: Map<string, Command<any>>;
   versionOptions?: DefaultOption | false;
   helpOptions?: DefaultOption | false;
+  autoHelp?: boolean;
 }
 
 interface CommandProps {
@@ -148,6 +149,22 @@ interface BuilderProps {
 
 export interface SubCommandOptions {
   override?: boolean;
+}
+
+export interface CustomHelpOptions {
+  /**
+   * If enabled, the help text will be shown automatically when a command, which
+   * has subcommands and no action handler defined, is executed without any
+   * arguments or options.
+   *
+   * This allows creating commands that only serve as a container for
+   * subcommands and don't have their own action handler, without the need to
+   * explicitly show help in the action handler of such commands.
+   *
+   * This option is enabled by default. To turn off the automatic help display,
+   * set this option to `false`.
+   */
+  auto?: boolean;
 }
 
 /**
@@ -843,10 +860,75 @@ export class Command<
       : this.settings.meta[name];
   }
 
+  public help(helpOptions: HelpOptions & CustomHelpOptions): this;
+
+  public help(
+    customHelp: string | HelpHandler,
+    customHelpOptions?: CustomHelpOptions,
+  ): this;
+
   /**
-   * Set command help.
+   * Set help options or define a custom help handler or help string.
    *
-   * @param help Help string, method, or config for generator that returns the help string.
+   * @param help Options for the build-in help generator or a custom help string
+   * or function that generates the help string. If the help is a function, it
+   * receives the command instance and the help options as parameters and should
+   * return the help string. If the help is a string, it is returned as is when
+   * the help is called.
+   * @param customHelpOptions Custom help options. If the first parameter is an
+   * object, it is treated as custom help options and the default help generator
+   * will be used to generate the help text based on these options.
+   *
+   * @example Help options
+   *
+   * ```ts
+   * import { Command } from "@cliffy/command";
+   *
+   * await new Command()
+   *   .name("demo")
+   *   .help({ auto: true })
+   *   .parse();
+   * ```
+   *
+   * @example Custom help string
+   *
+   * ```ts
+   * import { Command } from "@cliffy/command";
+   *
+   * await new Command()
+   *   .name("demo")
+   *   .help("This is a custom help string.")
+   *   .parse();
+   * ```
+   *
+   * @example Custom help handler
+   *
+   * ```ts
+   * import { Command } from "@cliffy/command";
+   *
+   * await new Command()
+   *   .name("demo")
+   *   .help((cmd) => {
+   *     return `This is a custom help string for command ${cmd.getName()}.`;
+   *   })
+   *   .parse();
+   * ```
+   *
+   * @example Help help handler with options
+   *
+   * ```ts
+   * import { Command } from "@cliffy/command";
+   *
+   * await new Command()
+   *   .name("demo")
+   *   .help(
+   *     (cmd, options) => {
+   *       return `This is a custom help string for command ${cmd.getName()} with options: ${JSON.stringify(options)}.`;
+   *     },
+   *     { auto: true },
+   *   )
+   *   .parse();
+   * ```
    */
   public help(
     help:
@@ -857,16 +939,25 @@ export class Command<
         TCommandGlobals,
         TParentCommandGlobals
       >
-      | HelpOptions,
+      | HelpOptions & CustomHelpOptions,
+    customHelpOptions?: CustomHelpOptions,
   ): this {
-    if (typeof help === "string") {
-      this.cmd.settings.help = () => help;
-    } else if (typeof help === "function") {
-      this.cmd.settings.help = help;
-    } else {
+    if (typeof help === "object") {
+      customHelpOptions = help;
       this.cmd.settings.help = (cmd: Command, options: HelpOptions): string =>
         HelpGenerator.generate(cmd, { ...help, ...options });
+    } else {
+      if (typeof help === "string") {
+        this.cmd.settings.help = () => help;
+      } else if (typeof help === "function") {
+        this.cmd.settings.help = help;
+      }
     }
+
+    if (customHelpOptions?.auto) {
+      this.cmd.settings.autoHelp = true;
+    }
+
     return this;
   }
 
@@ -2064,7 +2155,10 @@ export class Command<
       this.registerDefaults();
       this.props.rawArgs = ctx.unknown.slice();
 
-      if (!ctx.unknown.length && this.settings.defaultCommand) {
+      if (
+        this.settings.defaultCommand && !ctx.parsedFlags.length &&
+        !ctx.unknown.length
+      ) {
         const defaultCommand = this.getCommand(
           this.settings.defaultCommand,
           true,
@@ -2083,7 +2177,7 @@ export class Command<
 
       if (this.settings.useRawArgs) {
         await this.parseEnvVars(ctx, this.builder.envVars);
-        return await this.execute(ctx.env, ctx.unknown);
+        return await this.execute(ctx.env, ctx.unknown, ctx);
       }
 
       let preParseGlobals = false;
@@ -2140,7 +2234,7 @@ export class Command<
         }
       }
 
-      return await this.execute(options, args);
+      return await this.execute(options, args, ctx);
     } catch (error: unknown) {
       this.handleError(error);
     }
@@ -2302,18 +2396,30 @@ export class Command<
 
   /**
    * Execute command.
-   * @param options A map of options.
-   * @param args Command arguments.
+   * @param options A map of all options and environment variables. This also
+   * includes global options and environment variables. The options are parsed
+   * and processed by the command before passed to the action handler.
+   * @param args Positional arguments array.
+   * @param ctx Parse context.
    */
   private async execute(
     options: Record<string, unknown>,
     args: Array<unknown>,
+    ctx: ParseContext,
   ): Promise<CommandResult> {
-    await this.executeGlobalAction(options, args);
-
-    if (this.settings.actionHandler) {
-      await this.settings.actionHandler.call(this, options, ...args);
+    // Show help if auto help is enabled, the command has sub commands, was
+    // called without any arguments or options and has no action handler.
+    if (
+      this.settings.commands.size && !ctx.unknown.length &&
+      !ctx.parsedFlags.length && !this.settings.actionHandler &&
+      !this.settings.allowEmpty && this.isAutoHelpEnabled()
+    ) {
+      this.showHelp();
+      this.exit();
     }
+
+    await this.executeGlobalAction(options, args);
+    await this.settings.actionHandler?.call(this, options, ...args);
 
     return {
       options,
@@ -3325,6 +3431,10 @@ export class Command<
 
   private getHelpOption(): Option | undefined {
     return this.props.helpOption ?? this.parent?.getHelpOption();
+  }
+
+  private isAutoHelpEnabled(): boolean {
+    return this.settings.autoHelp ?? this.parent?.isAutoHelpEnabled() ?? true;
   }
 }
 

--- a/command/test/command/__snapshots__/help_test.ts.snap
+++ b/command/test/command/__snapshots__/help_test.ts.snap
@@ -66,3 +66,142 @@ Commands:
 stderr:
 ""
 `;
+
+snapshot[`should not show help when auto help option is enabled if action handler is defined even if no arguments are provided > mainCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should not show help when auto help option is enabled if action handler is defined even if no arguments are provided > fooCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should not show help when auto help option is enabled if action handler is defined even if no arguments are provided > barCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should show help when auto help option is enabled for commands with subcommands and no action handler if no arguments are provided > mainCommand 1`] = `
+stdout:
+"
+Usage: auto-help-test
+
+Description:
+
+  Test auto help option.
+
+Options:
+
+  -h, --help  - Show this help.  
+
+Commands:
+
+  foo  - 
+
+"
+stderr:
+""
+`;
+
+snapshot[`should show help when auto help option is enabled for commands with subcommands and no action handler if no arguments are provided > fooCommand 1`] = `
+stdout:
+"
+Usage: auto-help-test foo
+
+Options:
+
+  -h, --help  - Show this help.  
+
+Commands:
+
+  bar  - A subcommand.      
+  baz  - Another subcommand.
+
+"
+stderr:
+""
+`;
+
+snapshot[`should show help when auto help option is enabled for commands with subcommands and no action handler if no arguments are provided > barCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should show help when auto help option is enabled with global environment variable defined > mainCommand 1`] = `
+stdout:
+"
+Usage: auto-help-test
+
+Description:
+
+  Test auto help option.
+
+Options:
+
+  -h, --help  - Show this help.  
+
+Commands:
+
+  foo  - 
+
+Environment variables:
+
+  NO_COLOR  <value>  - Disable colors in help output.  
+
+"
+stderr:
+""
+`;
+
+snapshot[`should show help when auto help option is enabled with global environment variable defined > fooCommand 1`] = `
+stdout:
+"
+Usage: auto-help-test foo
+
+Options:
+
+  -h, --help  - Show this help.  
+
+Commands:
+
+  bar  - A subcommand.      
+  baz  - Another subcommand.
+
+Environment variables:
+
+  NO_COLOR  <value>  - Disable colors in help output.  
+
+"
+stderr:
+""
+`;
+
+snapshot[`should show help when auto help option is enabled with global environment variable defined > barCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should not show help when auto help option is enabled but no subcommands are defined > noArgs 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should not show help when auto help option is enabled but no subcommands are defined > withArgs 1`] = `
+stdout:
+""
+stderr:
+""
+`;

--- a/command/test/command/__snapshots__/help_test.ts.snap
+++ b/command/test/command/__snapshots__/help_test.ts.snap
@@ -205,3 +205,17 @@ stdout:
 stderr:
 ""
 `;
+
+snapshot[`should not show help when auto help is disabled for commands with subcommands and no action handler if no arguments are provided > mainCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;
+
+snapshot[`should not show help when auto help is disabled for commands with subcommands and no action handler if no arguments are provided > fooCommand 1`] = `
+stdout:
+""
+stderr:
+""
+`;

--- a/command/test/command/env_var_test.ts
+++ b/command/test/command/env_var_test.ts
@@ -44,6 +44,7 @@ function command() {
       "--global-prefixed <value>",
       "...",
     )
+    .action(() => {})
     .command(
       "bar",
       new Command()

--- a/command/test/command/help_test.ts
+++ b/command/test/command/help_test.ts
@@ -2,6 +2,8 @@ import { test } from "@cliffy/internal/testing/test";
 import { assertEquals } from "@std/assert";
 import { Command } from "../../command.ts";
 import { snapshotTest } from "../../../testing/mod.ts";
+import { deleteEnv } from "../../../internal/runtime/delete_env.ts";
+import { setEnv } from "../../../internal/runtime/set_env.ts";
 
 test("[command] help - help string", () => {
   const cmd = new Command()
@@ -234,5 +236,103 @@ await snapshotTest({
       .action(() => console.log("Fetching..."));
 
     await cmd.parse();
+  },
+});
+
+await snapshotTest({
+  name:
+    "should not show help when auto help option is enabled if action handler is defined even if no arguments are provided",
+  meta: import.meta,
+  steps: {
+    mainCommand: { args: [] },
+    fooCommand: { args: ["foo"] },
+    barCommand: { args: ["foo", "bar"] },
+  },
+  async fn(): Promise<void> {
+    const fooCommand = new Command()
+      .action(() => {})
+      .command("bar", "A subcommand.")
+      .command("baz", "Another subcommand.");
+
+    await new Command()
+      .name("auto-help-test")
+      .description("Test auto help option.")
+      .help({ auto: true })
+      .noExit()
+      .action(() => {})
+      .command("foo", fooCommand)
+      .parse();
+  },
+});
+
+await snapshotTest({
+  name:
+    "should show help when auto help option is enabled for commands with subcommands and no action handler if no arguments are provided",
+  meta: import.meta,
+  steps: {
+    mainCommand: { args: [] },
+    fooCommand: { args: ["foo"] },
+    barCommand: { args: ["foo", "bar"] },
+  },
+  async fn(): Promise<void> {
+    const fooCommand = new Command()
+      .command("bar", "A subcommand.")
+      .command("baz", "Another subcommand.");
+
+    await new Command()
+      .name("auto-help-test")
+      .description("Test auto help option.")
+      .help({ auto: true })
+      .noExit()
+      .command("foo", fooCommand)
+      .parse();
+  },
+});
+
+await snapshotTest({
+  name:
+    "should show help when auto help option is enabled with global environment variable defined",
+  meta: import.meta,
+  denoArgs: ["--quiet", "--allow-env"],
+  steps: {
+    mainCommand: { args: [] },
+    fooCommand: { args: ["foo"] },
+    barCommand: { args: ["foo", "bar"] },
+  },
+  async fn(): Promise<void> {
+    setEnv("NO_COLOR", "1");
+
+    const fooCommand = new Command()
+      .command("bar", "A subcommand.")
+      .command("baz", "Another subcommand.");
+
+    await new Command()
+      .name("auto-help-test")
+      .description("Test auto help option.")
+      .globalEnv("NO_COLOR", "Disable colors in help output.")
+      .help({ auto: true })
+      .noExit()
+      .command("foo", fooCommand)
+      .parse();
+
+    deleteEnv("NO_COLOR");
+  },
+});
+
+await snapshotTest({
+  name:
+    "should not show help when auto help option is enabled but no subcommands are defined",
+  meta: import.meta,
+  steps: {
+    noArgs: { args: [] },
+    withArgs: { args: ["-f"] },
+  },
+  async fn(): Promise<void> {
+    await new Command()
+      .option("-f, --foo", "Foo option.")
+      .option("-b, --bar", "Bar option.")
+      .help({ auto: true })
+      .noExit()
+      .parse();
   },
 });

--- a/command/test/command/help_test.ts
+++ b/command/test/command/help_test.ts
@@ -336,3 +336,26 @@ await snapshotTest({
       .parse();
   },
 });
+
+await snapshotTest({
+  name:
+    "should not show help when auto help is disabled for commands with subcommands and no action handler if no arguments are provided",
+  meta: import.meta,
+  steps: {
+    mainCommand: { args: [] },
+    fooCommand: { args: ["foo"] },
+  },
+  async fn(): Promise<void> {
+    const fooCommand = new Command()
+      .command("bar", "A subcommand.")
+      .command("baz", "Another subcommand.");
+
+    await new Command()
+      .name("auto-help-test")
+      .description("Test auto help option.")
+      .help({ auto: false })
+      .noExit()
+      .command("foo", fooCommand)
+      .parse();
+  },
+});


### PR DESCRIPTION
add support for automatically displaying help when a command with only subcommands and no action handler is invoked without arguments. this behavior is enabled by default and can be configured via the new `auto` option in the help method.

#closes #827