### PR TITLE
fix(prompt): treat `h` and `l` as search input when `search` is enabled

### DIFF
--- a/prompt/_generic_list.ts
+++ b/prompt/_generic_list.ts
@@ -224,8 +224,8 @@ export abstract class GenericList<
       keys: {
         next: options.search ? ["down"] : ["down", "j", "d", "n", "2"],
         previous: options.search ? ["up"] : ["up", "k", "u", "p", "8"],
-        nextPage: ["pagedown", "right", "l"],
-        previousPage: ["pageup", "left", "h"],
+        nextPage: options.search ? ["pagedown"] : ["pagedown", "right", "l"],
+        previousPage: options.search ? ["pageup"] : ["pageup", "left", "h"],
         open: ["right", "enter", "return"],
         back: ["left", "escape", "enter", "return"],
         ...(settings.keys ?? {}),

--- a/prompt/test/integration/__snapshots__/checkbox_test.ts.snap
+++ b/prompt/test/integration/__snapshots__/checkbox_test.ts.snap
@@ -50,6 +50,34 @@ stderr:
 ""
 `;
 
+snapshot[`checkbox prompt > should treat h and l as search input 1`] = `
+stdout:
+"? Select an option 🔎 
+❯ ✘ Foo
+  ✘ Bar
+  ✘ html
+  ✘ Baz\\x1b[4A\\x1b[23G\\x1b[G\\x1b[0J
+? Select an option 🔎 h
+  ✘ html\\x1b[1A\\x1b[24G\\x1b[G\\x1b[0J
+? Select an option 🔎 ht
+  ✘ html\\x1b[1A\\x1b[25G\\x1b[G\\x1b[0J
+? Select an option 🔎 htm
+  ✘ html\\x1b[1A\\x1b[26G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+  ✘ html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ ✘ html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ ✔ html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ ✔ html
+Press ↵ again to submit. To check or uncheck the selected option press space.\\x1b[2A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option › html
+\\x1b[?25h\\x1b[?25h"
+stderr:
+""
+`;
+
 snapshot[`checkbox prompt > should format option value 1`] = `
 stdout:
 "? Message...

--- a/prompt/test/integration/__snapshots__/checkbox_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/checkbox_test.ts.windows.snap
@@ -50,6 +50,34 @@ stderr:
 ""
 `;
 
+snapshot[`checkbox prompt > should treat h and l as search input 1`] = `
+stdout:
+"? Select an option 🔎
+❯ × Foo
+  × Bar
+  × html
+  × Baz\\x1b[4A\\x1b[23G\\x1b[G\\x1b[0J
+? Select an option 🔎 h
+  × html\\x1b[1A\\x1b[24G\\x1b[G\\x1b[0J
+? Select an option 🔎 ht
+  × html\\x1b[1A\\x1b[25G\\x1b[G\\x1b[0J
+? Select an option 🔎 htm
+  × html\\x1b[1A\\x1b[26G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+  × html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ × html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ √ html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ √ html
+Press ↵ again to submit. To check or uncheck the selected option press space.\\x1b[2A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option » html
+\\x1b[?25h\\x1b[?25h"
+stderr:
+""
+`;
+
 snapshot[`checkbox prompt > should format option value 1`] = `
 stdout:
 "? Message...

--- a/prompt/test/integration/__snapshots__/checkbox_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/checkbox_test.ts.windows.snap
@@ -52,7 +52,7 @@ stderr:
 
 snapshot[`checkbox prompt > should treat h and l as search input 1`] = `
 stdout:
-"? Select an option 🔎
+"? Select an option 🔎 
 ❯ × Foo
   × Bar
   × html

--- a/prompt/test/integration/__snapshots__/select_test.ts.snap
+++ b/prompt/test/integration/__snapshots__/select_test.ts.snap
@@ -34,6 +34,27 @@ stderr:
 ""
 `;
 
+snapshot[`select prompt > should treat h and l as search input 1`] = `
+stdout:
+"? Select an option 🔎 
+❯ Foo
+  Bar
+  html
+  Baz\\x1b[4A\\x1b[23G\\x1b[G\\x1b[0J
+? Select an option 🔎 h
+❯ html\\x1b[1A\\x1b[24G\\x1b[G\\x1b[0J
+? Select an option 🔎 ht
+❯ html\\x1b[1A\\x1b[25G\\x1b[G\\x1b[0J
+? Select an option 🔎 htm
+❯ html\\x1b[1A\\x1b[26G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option › html
+\\x1b[?25h\\x1b[?25h"
+stderr:
+""
+`;
+
 snapshot[`select prompt > should format option value 1`] = `
 stdout:
 "? Message...

--- a/prompt/test/integration/__snapshots__/select_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/select_test.ts.windows.snap
@@ -36,7 +36,7 @@ stderr:
 
 snapshot[`select prompt > should treat h and l as search input 1`] = `
 stdout:
-"? Select an option 🔎
+"? Select an option 🔎 
 ❯ Foo
   Bar
   html

--- a/prompt/test/integration/__snapshots__/select_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/select_test.ts.windows.snap
@@ -34,6 +34,27 @@ stderr:
 ""
 `;
 
+snapshot[`select prompt > should treat h and l as search input 1`] = `
+stdout:
+"? Select an option 🔎
+❯ Foo
+  Bar
+  html
+  Baz\\x1b[4A\\x1b[23G\\x1b[G\\x1b[0J
+? Select an option 🔎 h
+❯ html\\x1b[1A\\x1b[24G\\x1b[G\\x1b[0J
+? Select an option 🔎 ht
+❯ html\\x1b[1A\\x1b[25G\\x1b[G\\x1b[0J
+? Select an option 🔎 htm
+❯ html\\x1b[1A\\x1b[26G\\x1b[G\\x1b[0J
+? Select an option 🔎 html
+❯ html\\x1b[1A\\x1b[27G\\x1b[G\\x1b[0J
+? Select an option » html
+\\x1b[?25h\\x1b[?25h"
+stderr:
+""
+`;
+
 snapshot[`select prompt > should format option value 1`] = `
 stdout:
 "? Message...

--- a/prompt/test/integration/checkbox_test.ts
+++ b/prompt/test/integration/checkbox_test.ts
@@ -51,6 +51,34 @@ await snapshotTest({
 });
 
 await snapshotTest({
+  name: "checkbox prompt > should treat h and l as search input",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: ansi
+    .text("h")
+    .text("t")
+    .text("m")
+    .text("l")
+    .text("\n")
+    .text(" ")
+    .text("\n")
+    .text("\n")
+    .toArray(),
+  async fn() {
+    await Checkbox.prompt({
+      message: "Select an option",
+      search: true,
+      options: [
+        { name: "Foo", value: "foo" },
+        { name: "Bar", value: "bar" },
+        { name: "html", value: "html" },
+        { name: "Baz", value: "baz" },
+      ],
+    });
+  },
+});
+
+await snapshotTest({
   name: "checkbox prompt > should format option value",
   meta: import.meta,
   osSuffix: ["windows"],

--- a/prompt/test/integration/select_test.ts
+++ b/prompt/test/integration/select_test.ts
@@ -46,6 +46,31 @@ await snapshotTest({
 });
 
 await snapshotTest({
+  name: "select prompt > should treat h and l as search input",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: ansi
+    .text("h")
+    .text("t")
+    .text("m")
+    .text("l")
+    .text("\n")
+    .toArray(),
+  async fn() {
+    await Select.prompt({
+      message: "Select an option",
+      search: true,
+      options: [
+        { name: "Foo", value: "foo" },
+        { name: "Bar", value: "bar" },
+        { name: "html", value: "html" },
+        { name: "Baz", value: "baz" },
+      ],
+    });
+  },
+});
+
+await snapshotTest({
   name: "select prompt > should format option value",
   meta: import.meta,
   osSuffix: ["windows"],


### PR DESCRIPTION
fix #876