### PR TITLE
fix(command): respect minimum-dependency-age and min-release-age in upgrade command

### DIFF
--- a/command/upgrade/provider.ts
+++ b/command/upgrade/provider.ts
@@ -57,6 +57,15 @@ export abstract class Provider {
   protected logger: Logger;
   private maxCols = 8;
 
+  /**
+   * Whether resolving the `latest` target is delegated to the runtime /
+   * package manager instead of being resolved to a concrete version by the
+   * provider. Registries that support a min-release-age policy (npm, jsr)
+   * enable this so the runtime can downgrade to the newest version allowed by
+   * the configured policy. See {@link resolveSpecifierVersion}.
+   */
+  protected readonly delegateLatestResolution: boolean = false;
+
   protected constructor({ main, logger = console }: ProviderOptions = {}) {
     this.main = main;
     this.logger = logger;
@@ -74,6 +83,42 @@ export abstract class Provider {
 
   getSpecifier(name: string, version: string, defaultMain?: string): string {
     return `${this.getRegistryUrl(name, version)}${this.getMain(defaultMain)}`;
+  }
+
+  /**
+   * Resolve the requested target version to an installable version.
+   *
+   * By default the `latest` target is resolved to the concrete latest version
+   * reported by the registry. Providers that delegate resolution to the
+   * runtime (see {@link delegateLatestResolution}) keep the `latest` target
+   * unresolved so the runtime can apply its own min-release-age policy when
+   * installing the specifier produced by {@link resolveSpecifierVersion}.
+   */
+  async resolveVersion(name: string, version: string): Promise<string> {
+    if (version === "latest" && !this.delegateLatestResolution) {
+      const { latest } = await this.getVersions(name);
+      return latest;
+    }
+    return version;
+  }
+
+  /**
+   * Map the version part of an install specifier.
+   *
+   * For providers that delegate resolution, the `latest` target is mapped to
+   * the `*` semver range instead of the `latest` dist-tag. This lets the
+   * runtime / package manager downgrade to the newest version permitted by a
+   * configured minimumDependencyAge (deno) or min-release-age (npm/pnpm/bun).
+   *
+   * `*` is used rather than the `latest` tag because Deno rejects a too-new
+   * tag instead of downgrading it (npm and bun downgrade the tag either way,
+   * and jsr has no `latest` tag at all). Use the `latest` tag once deno
+   * resolves tags like npm/pnpm/bun do: https://github.com/denoland/deno/issues/34579
+   */
+  protected resolveSpecifierVersion(version: string): string {
+    return this.delegateLatestResolution && version === "latest"
+      ? "*"
+      : version;
   }
 
   async isOutdated(

--- a/command/upgrade/provider/jsr.ts
+++ b/command/upgrade/provider/jsr.ts
@@ -26,6 +26,7 @@ export type JsrProviderOptions =
 
 export class JsrProvider extends Provider {
   name = "jsr";
+  protected override readonly delegateLatestResolution = true;
   private readonly repositoryUrl = "https://jsr.io/";
   private readonly packageName?: string;
   private readonly packageScope: string;
@@ -76,7 +77,9 @@ export class JsrProvider extends Provider {
     ).href;
   }
 
-  getRegistryUrl(name: string, version: Semver): string {
-    return `jsr:@${this.packageScope}/${this.packageName ?? name}@${version}`;
+  getRegistryUrl(name: string, version: string): string {
+    return `jsr:@${this.packageScope}/${this.packageName ?? name}@${
+      this.resolveSpecifierVersion(version)
+    }`;
   }
 }

--- a/command/upgrade/provider/jsr_test.ts
+++ b/command/upgrade/provider/jsr_test.ts
@@ -37,6 +37,16 @@ test({
     });
 
     await ctx.step({
+      name: "should map the latest target to a wildcard registry url",
+      fn() {
+        assertEquals(
+          provider.getRegistryUrl("foo", "latest"),
+          "jsr:@example/foo@*",
+        );
+      },
+    });
+
+    await ctx.step({
       name: "should return repository url",
       fn() {
         assertEquals(
@@ -99,7 +109,7 @@ test({
     });
 
     await ctx.step({
-      name: "should upgrade to latest version",
+      name: "should upgrade to latest version using a wildcard specifier",
       ignore: ["node"],
       async fn() {
         const versionsResponse = {
@@ -111,7 +121,9 @@ test({
             },
           }),
         };
-        mockFetch("https://jsr.io/@example/foo/meta.json", versionsResponse);
+        // Only the isOutdated check fetches the versions; resolving the latest
+        // target is delegated to the runtime so the install specifier keeps the
+        // `@*` range instead of pinning a concrete version (#877).
         mockFetch("https://jsr.io/@example/foo/meta.json", versionsResponse);
 
         mockCommand({
@@ -122,7 +134,7 @@ test({
             "--global",
             "--force",
             "--quiet",
-            "jsr:@example/foo@1.0.1",
+            "jsr:@example/foo@*",
           ],
           stdout: "piped",
           stderr: "piped",
@@ -136,6 +148,36 @@ test({
         });
 
         resetFetch();
+        resetCommand();
+      },
+    });
+
+    await ctx.step({
+      name: "should upgrade to an explicit version using a pinned specifier",
+      ignore: ["node"],
+      async fn() {
+        mockCommand({
+          command: Deno.execPath(),
+          args: [
+            "install",
+            "--name=foo",
+            "--global",
+            "--force",
+            "--quiet",
+            "jsr:@example/foo@1.0.0",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+
+        await upgrade({
+          name: "foo",
+          from: "0.9.0",
+          to: "1.0.0",
+          provider,
+          force: true,
+        });
+
         resetCommand();
       },
     });

--- a/command/upgrade/provider/npm.ts
+++ b/command/upgrade/provider/npm.ts
@@ -11,6 +11,7 @@ export type NpmProviderOptions =
 
 export class NpmProvider extends Provider {
   name = "npm";
+  protected override readonly delegateLatestResolution = true;
   private readonly repositoryUrl = "https://npmjs.org/";
   private readonly apiUrl = "https://registry.npmjs.org/";
   private readonly packageName?: string;
@@ -69,7 +70,9 @@ export class NpmProvider extends Provider {
   }
 
   getRegistryUrl(name: string, version: string): string {
-    return `npm:${this.#getPackageName(name)}@${version}`;
+    return `npm:${this.#getPackageName(name)}@${
+      this.resolveSpecifierVersion(version)
+    }`;
   }
 
   #getPackageName(name: string): string {

--- a/command/upgrade/provider/npm_test.ts
+++ b/command/upgrade/provider/npm_test.ts
@@ -65,6 +65,16 @@ test({
     });
 
     await ctx.step({
+      name: "should map the latest target to a wildcard registry url",
+      fn() {
+        assertEquals(
+          provider.getRegistryUrl("foo", "latest"),
+          "npm:@example/foo@*",
+        );
+      },
+    });
+
+    await ctx.step({
       name: "should return repository url",
       fn() {
         assertEquals(
@@ -131,7 +141,7 @@ test({
     });
 
     await ctx.step({
-      name: "should upgrade to latest version",
+      name: "should upgrade to latest version using a wildcard specifier",
       ignore: ["node"],
       async fn() {
         const versionResponse = {
@@ -145,7 +155,9 @@ test({
             },
           }),
         };
-        mockFetch("https://registry.npmjs.org/@example/foo", versionResponse);
+        // Only the isOutdated check fetches the versions; resolving the latest
+        // target is delegated to the runtime so the install specifier keeps the
+        // `@*` range instead of pinning a concrete version (#877).
         mockFetch("https://registry.npmjs.org/@example/foo", versionResponse);
 
         mockCommand({
@@ -156,7 +168,7 @@ test({
             "--global",
             "--force",
             "--quiet",
-            "npm:@example/foo@1.0.1",
+            "npm:@example/foo@*",
           ],
           stdout: "piped",
           stderr: "piped",
@@ -170,6 +182,36 @@ test({
         });
 
         resetFetch();
+        resetCommand();
+      },
+    });
+
+    await ctx.step({
+      name: "should upgrade to an explicit version using a pinned specifier",
+      ignore: ["node"],
+      async fn() {
+        mockCommand({
+          command: Deno.execPath(),
+          args: [
+            "install",
+            "--name=foo",
+            "--global",
+            "--force",
+            "--quiet",
+            "npm:@example/foo@1.0.0",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+
+        await upgrade({
+          name: "foo",
+          from: "0.9.0",
+          to: "1.0.0",
+          provider,
+          force: true,
+        });
+
         resetCommand();
       },
     });

--- a/command/upgrade/upgrade.ts
+++ b/command/upgrade/upgrade.ts
@@ -47,8 +47,6 @@ export async function upgrade(
         options.name,
         options.to,
       );
-      const { latest } = await provider.getVersions(options.name);
-      options.to = latest;
     } else {
       options.logger?.log(
         dim("Upgrading %s to version %s"),
@@ -56,6 +54,7 @@ export async function upgrade(
         options.to,
       );
     }
+    options.to = await provider.resolveVersion(options.name, options.to);
     options.logger?.log(dim("Upgrading %s:"), options.name);
     options.logger?.log(dim("  - current version: %s"), options.from);
     options.logger?.log(dim("  - target version: %s"), options.to);


### PR DESCRIPTION
fix #877