### PR TITLE
feat(prompt): add word navigation and deletion

### DIFF
--- a/prompt/_generic_input.ts
+++ b/prompt/_generic_input.ts
@@ -30,6 +30,14 @@ export interface GenericInputKeys extends GenericPromptKeys {
   deleteCharLeft?: string[];
   /** Delete cursor right keymap. Default is `["delete"]`. */
   deleteCharRight?: string[];
+  /** Move cursor one word left. Default is `["alt+left", "ctrl+left"]`. */
+  moveWordLeft?: string[];
+  /** Move cursor one word right. Default is `["alt+right", "ctrl+right"]`. */
+  moveWordRight?: string[];
+  /** Delete word to the left of cursor. Default is `["ctrl+w", "alt+backspace"]`. */
+  deleteWordLeft?: string[];
+  /** Delete word to the right of cursor. Default is `["alt+d"]`. */
+  deleteWordRight?: string[];
 }
 
 /** Generic input prompt representation. */
@@ -56,6 +64,10 @@ export abstract class GenericInput<
         moveCursorRight: ["right"],
         deleteCharLeft: ["backspace"],
         deleteCharRight: ["delete"],
+        moveWordLeft: ["alt+left", "ctrl+left"],
+        moveWordRight: ["alt+right", "ctrl+right"],
+        deleteWordLeft: ["ctrl+w", "alt+backspace"],
+        deleteWordRight: ["alt+d"],
         ...(settings.keys ?? {}),
       },
     };
@@ -81,6 +93,18 @@ export abstract class GenericInput<
    */
   protected override async handleEvent(event: KeyCode): Promise<void> {
     switch (true) {
+      case this.isKey(this.settings.keys, "moveWordLeft", event):
+        this.moveWordLeft();
+        break;
+      case this.isKey(this.settings.keys, "moveWordRight", event):
+        this.moveWordRight();
+        break;
+      case this.isKey(this.settings.keys, "deleteWordLeft", event):
+        this.deleteWordLeft();
+        break;
+      case this.isKey(this.settings.keys, "deleteWordRight", event):
+        this.deleteWordRight();
+        break;
       case this.isKey(this.settings.keys, "moveCursorLeft", event):
         this.moveCursorLeft();
         break;
@@ -136,5 +160,56 @@ export abstract class GenericInput<
       this.inputValue = this.inputValue.slice(0, this.inputIndex) +
         this.inputValue.slice(this.inputIndex + 1);
     }
+  }
+
+  /** Move cursor one word to the left (whitespace-delimited). */
+  protected moveWordLeft(): void {
+    let i = this.inputIndex;
+    while (i > 0 && this.inputValue[i - 1] === " ") {
+      i--;
+    }
+    while (i > 0 && this.inputValue[i - 1] !== " ") {
+      i--;
+    }
+    this.inputIndex = i;
+  }
+
+  /** Move cursor one word to the right (whitespace-delimited). */
+  protected moveWordRight(): void {
+    let i = this.inputIndex;
+    while (i < this.inputValue.length && this.inputValue[i] !== " ") {
+      i++;
+    }
+    while (i < this.inputValue.length && this.inputValue[i] === " ") {
+      i++;
+    }
+    this.inputIndex = i;
+  }
+
+  /** Delete the word to the left of the cursor (whitespace-delimited). */
+  protected deleteWordLeft(): void {
+    let i = this.inputIndex;
+    while (i > 0 && this.inputValue[i - 1] === " ") {
+      i--;
+    }
+    while (i > 0 && this.inputValue[i - 1] !== " ") {
+      i--;
+    }
+    this.inputValue = this.inputValue.slice(0, i) +
+      this.inputValue.slice(this.inputIndex);
+    this.inputIndex = i;
+  }
+
+  /** Delete the word to the right of the cursor (whitespace-delimited). */
+  protected deleteWordRight(): void {
+    let i = this.inputIndex;
+    while (i < this.inputValue.length && this.inputValue[i] !== " ") {
+      i++;
+    }
+    while (i < this.inputValue.length && this.inputValue[i] === " ") {
+      i++;
+    }
+    this.inputValue = this.inputValue.slice(0, this.inputIndex) +
+      this.inputValue.slice(i);
   }
 }

--- a/prompt/_generic_suggestions.ts
+++ b/prompt/_generic_suggestions.ts
@@ -482,6 +482,12 @@ export abstract class GenericSuggestions<TValue, TRawValue>
       case this.isKey(this.settings.keys, "deselect", event):
         this.deselectSuggestion();
         break;
+      case this.isKey(this.settings.keys, "moveWordLeft", event):
+        this.moveWordLeft();
+        break;
+      case this.isKey(this.settings.keys, "moveWordRight", event):
+        this.moveWordRight();
+        break;
       case this.isKey(this.settings.keys, "moveCursorRight", event):
         if (this.inputIndex < this.inputValue.length) {
           this.moveCursorRight();

--- a/prompt/test/input_test.ts
+++ b/prompt/test/input_test.ts
@@ -4,6 +4,33 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { bold, red } from "@std/fmt/colors";
 import { Input } from "../input.ts";
 
+class InputTester extends Input {
+  get value(): string {
+    return this.inputValue;
+  }
+  set value(v: string) {
+    this.inputValue = v;
+  }
+  get index(): number {
+    return this.inputIndex;
+  }
+  set index(i: number) {
+    this.inputIndex = i;
+  }
+  public override moveWordLeft(): void {
+    super.moveWordLeft();
+  }
+  public override moveWordRight(): void {
+    super.moveWordRight();
+  }
+  public override deleteWordLeft(): void {
+    super.deleteWordLeft();
+  }
+  public override deleteWordRight(): void {
+    super.deleteWordRight();
+  }
+}
+
 test("prompt input: value", async () => {
   Input.inject("hallo");
   const result: string | undefined = await Input.prompt("message");
@@ -75,4 +102,131 @@ test("prompt input: null value", async () => {
       `${getOs() === "windows" ? bold("× ") : bold("✘ ")}Invalid answer.`,
     ),
   );
+});
+
+test("prompt input: should move word left from end of input", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 11;
+  t.moveWordLeft();
+  assertEquals(t.index, 6);
+});
+
+test("prompt input: should move word left from middle of input", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 6;
+  t.moveWordLeft();
+  assertEquals(t.index, 0);
+});
+
+test("prompt input: should not move word left past start", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 0;
+  t.moveWordLeft();
+  assertEquals(t.index, 0);
+});
+
+test("prompt input: should skip leading whitespace when moving word left", () => {
+  const t = new InputTester("test");
+  t.value = "  hello";
+  t.index = 7;
+  t.moveWordLeft();
+  assertEquals(t.index, 2);
+});
+
+test("prompt input: should move word right from start of input", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 0;
+  t.moveWordRight();
+  assertEquals(t.index, 6);
+});
+
+test("prompt input: should move word right to end when no next word", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 6;
+  t.moveWordRight();
+  assertEquals(t.index, 11);
+});
+
+test("prompt input: should not move word right past end", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 11;
+  t.moveWordRight();
+  assertEquals(t.index, 11);
+});
+
+test("prompt input: should skip multiple spaces when moving word right", () => {
+  const t = new InputTester("test");
+  t.value = "hello  world";
+  t.index = 0;
+  t.moveWordRight();
+  assertEquals(t.index, 7);
+});
+
+test("prompt input: should delete word to the left from end", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 11;
+  t.deleteWordLeft();
+  assertEquals(t.value, "hello ");
+  assertEquals(t.index, 6);
+});
+
+test("prompt input: should delete word to the left including preceding space", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 6;
+  t.deleteWordLeft();
+  assertEquals(t.value, "world");
+  assertEquals(t.index, 0);
+});
+
+test("prompt input: should not delete word to the left at start", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 0;
+  t.deleteWordLeft();
+  assertEquals(t.value, "hello world");
+  assertEquals(t.index, 0);
+});
+
+test("prompt input: should delete entire single word to the left", () => {
+  const t = new InputTester("test");
+  t.value = "hello";
+  t.index = 5;
+  t.deleteWordLeft();
+  assertEquals(t.value, "");
+  assertEquals(t.index, 0);
+});
+
+test("prompt input: should delete word to the right from start", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 0;
+  t.deleteWordRight();
+  assertEquals(t.value, "world");
+  assertEquals(t.index, 0);
+});
+
+test("prompt input: should not delete word to the right at end", () => {
+  const t = new InputTester("test");
+  t.value = "hello world";
+  t.index = 11;
+  t.deleteWordRight();
+  assertEquals(t.value, "hello world");
+  assertEquals(t.index, 11);
+});
+
+test("prompt input: should delete entire single word to the right", () => {
+  const t = new InputTester("test");
+  t.value = "hello";
+  t.index = 0;
+  t.deleteWordRight();
+  assertEquals(t.value, "");
+  assertEquals(t.index, 0);
 });

--- a/prompt/test/integration/__snapshots__/input_test.ts.snap
+++ b/prompt/test/integration/__snapshots__/input_test.ts.snap
@@ -195,3 +195,58 @@ stdout:
 stderr:
 ""
 `;
+
+snapshot[`input prompt > should delete word to the left with ctrl+w 1`] = `
+stdout:
+"? Enter text › \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › hello wo\\x1b[24G\\x1b[G\\x1b[0J
+? Enter text › hello world\\x1b[27G\\x1b[G\\x1b[0J
+? Enter text › hello \\x1b[22G\\x1b[G\\x1b[0J
+? Enter text › hello
+\\x1b[?25h\\x1b[?25hhello
+"
+stderr:
+""
+`;
+
+snapshot[`input prompt > should delete word to the right with alt+d 1`] = `
+stdout:
+"? Enter text › \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › foo bar\\x1b[23G\\x1b[G\\x1b[0J
+? Enter text › foo bar\\x1b[20G\\x1b[G\\x1b[0J
+? Enter text › foo bar\\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › bar\\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › bar
+\\x1b[?25h\\x1b[?25hbar
+"
+stderr:
+""
+`;
+
+snapshot[`input prompt > should move cursor one word left with alt+left 1`] = `
+stdout:
+"? Enter text › \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › hello wo\\x1b[24G\\x1b[G\\x1b[0J
+? Enter text › hello world\\x1b[27G\\x1b[G\\x1b[0J
+? Enter text › hello world\\x1b[22G\\x1b[G\\x1b[0J
+? Enter text › hello Xworld\\x1b[23G\\x1b[G\\x1b[0J
+? Enter text › hello Xworld
+\\x1b[?25h\\x1b[?25hhello Xworld
+"
+stderr:
+""
+`;
+
+snapshot[`input prompt > should move cursor one word right with alt+right 1`] = `
+stdout:
+"? Enter text › \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › foo\\x1b[19G\\x1b[G\\x1b[0J
+? Enter text › foo\\x1b[16G\\x1b[G\\x1b[0J
+? Enter text › foo\\x1b[19G\\x1b[G\\x1b[0J
+? Enter text › fooX\\x1b[20G\\x1b[G\\x1b[0J
+? Enter text › fooX
+\\x1b[?25h\\x1b[?25hfooX
+"
+stderr:
+""
+`;

--- a/prompt/test/integration/__snapshots__/input_test.ts.windows.snap
+++ b/prompt/test/integration/__snapshots__/input_test.ts.windows.snap
@@ -195,3 +195,58 @@ stdout:
 stderr:
 ""
 `;
+
+snapshot[`input prompt > should delete word to the left with ctrl+w 1`] = `
+stdout:
+"? Enter text » \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » hello wo\\x1b[24G\\x1b[G\\x1b[0J
+? Enter text » hello world\\x1b[27G\\x1b[G\\x1b[0J
+? Enter text » hello \\x1b[22G\\x1b[G\\x1b[0J
+? Enter text » hello
+\\x1b[?25h\\x1b[?25hhello
+"
+stderr:
+""
+`;
+
+snapshot[`input prompt > should delete word to the right with alt+d 1`] = `
+stdout:
+"? Enter text » \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » foo bar\\x1b[23G\\x1b[G\\x1b[0J
+? Enter text » foo bar\\x1b[20G\\x1b[G\\x1b[0J
+? Enter text » foo bar\\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » bar\\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » bar
+\\x1b[?25h\\x1b[?25hbar
+"
+stderr:
+""
+`;
+
+snapshot[`input prompt > should move cursor one word left with alt+left 1`] = `
+stdout:
+"? Enter text » \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » hello wo\\x1b[24G\\x1b[G\\x1b[0J
+? Enter text » hello world\\x1b[27G\\x1b[G\\x1b[0J
+? Enter text » hello world\\x1b[22G\\x1b[G\\x1b[0J
+? Enter text » hello Xworld\\x1b[23G\\x1b[G\\x1b[0J
+? Enter text » hello Xworld
+\\x1b[?25h\\x1b[?25hhello Xworld
+"
+stderr:
+""
+`;
+
+snapshot[`input prompt > should move cursor one word right with alt+right 1`] = `
+stdout:
+"? Enter text » \\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » foo\\x1b[19G\\x1b[G\\x1b[0J
+? Enter text » foo\\x1b[16G\\x1b[G\\x1b[0J
+? Enter text » foo\\x1b[19G\\x1b[G\\x1b[0J
+? Enter text » fooX\\x1b[20G\\x1b[G\\x1b[0J
+? Enter text » fooX
+\\x1b[?25h\\x1b[?25hfooX
+"
+stderr:
+""
+`;

--- a/prompt/test/integration/input_test.ts
+++ b/prompt/test/integration/input_test.ts
@@ -252,3 +252,68 @@ await snapshotTest({
     });
   },
 });
+
+await snapshotTest({
+  name: "input prompt > should delete word to the left with ctrl+w",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: [
+    "hello world",
+    "\x17", // ctrl+w
+    "\n",
+  ],
+  async fn() {
+    const result = await Input.prompt({ message: "Enter text" });
+    console.log(result);
+  },
+});
+
+await snapshotTest({
+  name: "input prompt > should delete word to the right with alt+d",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: [
+    "foo bar",
+    "\x1b[1;3D", // alt+left (to before "bar")
+    "\x1b[1;3D", // alt+left (to before "foo")
+    "\x1bd", // alt+d (delete "foo ")
+    "\n",
+  ],
+  async fn() {
+    const result = await Input.prompt({ message: "Enter text" });
+    console.log(result);
+  },
+});
+
+await snapshotTest({
+  name: "input prompt > should move cursor one word left with alt+left",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: [
+    "hello world",
+    "\x1b[1;3D", // alt+left (cursor to before "world")
+    "X",
+    "\n",
+  ],
+  async fn() {
+    const result = await Input.prompt({ message: "Enter text" });
+    console.log(result);
+  },
+});
+
+await snapshotTest({
+  name: "input prompt > should move cursor one word right with alt+right",
+  meta: import.meta,
+  osSuffix: ["windows"],
+  stdin: [
+    "foo",
+    "\x1b[1;3D", // alt+left (cursor to before "foo")
+    "\x1b[1;3C", // alt+right (cursor back to after "foo")
+    "X",
+    "\n",
+  ],
+  async fn() {
+    const result = await Input.prompt({ message: "Enter text" });
+    console.log(result);
+  },
+});


### PR DESCRIPTION
Default bindings:
- alt+left / ctrl+left - move word left
- alt+right / ctrl+right - move word right
- ctrl+w / alt+backspace - delete word left
- alt+d - delete word right