### PR TITLE
docs: clarify global option chaining

### DIFF
--- a/examples/command/global_options.ts
+++ b/examples/command/global_options.ts
@@ -4,6 +4,8 @@ import { Command } from "@cliffy/command";
 
 await new Command()
   .option("-l, --local [val:string]", "Only available on this command.")
+  // Define global options before adding child commands, or call `.reset()`
+  // before adding them, so the chain is back on the parent command.
   .globalOption(
     "-g, --global [val:string]",
     "Available on this and all nested child commands.",


### PR DESCRIPTION
## Summary

Clarifies in the global options example that chained calls after `.command()` apply to the current child command unless the chain is reset back to the parent.

Closes #776.

## Testing

Not run; documentation/comment-only change.