### PR TITLE
fix(command): escape backslashes in fish completion descriptions

### DIFF
--- a/command/completions/_fish_completions_generator.ts
+++ b/command/completions/_fish_completions_generator.ts
@@ -141,7 +141,8 @@ ${this.generateCompletions(this.name, this.cmd).trim()}`;
 
     if (options.description) {
       const description: string = getDescription(options.description, true)
-        // escape single quotes
+        // escape backslashes and single quotes
+        .replace(/\\/g, "\\\\")
         .replace(/'/g, "\\'");
 
       cmd.push("-d", `'${description}'`);

--- a/command/test/command/__snapshots__/completion_test.ts.snap
+++ b/command/test/command/__snapshots__/completion_test.ts.snap
@@ -333,6 +333,54 @@ stderr:
 ""
 `;
 
+snapshot[`should escape backslashes in option descriptions for fish completions > fish 1`] = `
+stdout:
+\`#!/usr/bin/env fish
+# fish completion support for completions-test v1.0.0
+
+function __fish_completions_test_using_command
+  set -l cmds __completions_test __completions_test_completions __completions_test_completions_bash __completions_test_completions_fish __completions_test_completions_zsh
+  set -l words (commandline -opc)
+  set -l cmd "_"
+  for word in \$words
+    switch \$word
+      case '-*'
+        continue
+      case '*'
+        set word (string replace -r -a '\\\\W' '_' \$word)
+        set -l cmd_tmp \$cmd"_\$word"
+        if contains \$cmd_tmp \$cmds
+          set cmd \$cmd_tmp
+        end
+    end
+  end
+  if test "\$cmd" = "\$argv[1]"
+    return 0
+  end
+  return 1
+end
+
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test' -s h -l help -x -k -f -d 'Show this help.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test' -s V -l version -x -k -f -d 'Show the version number for this program.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test' -l double-backslash -k -f -r -a '(completions-test completions complete string  2>/dev/null)' -d 'write a \\\\\\\\\\\\\\\\ for a backslash'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test' -l trailing-backslash -k -f -r -a '(completions-test completions complete string  2>/dev/null)' -d 'ends with a backslash\\\\\\\\'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test' -l single-quote -k -f -r -a '(completions-test completions complete string  2>/dev/null)' -d 'description with \\\\'single quotes\\\\''
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test' -k -f -a completions -d 'Generate shell completions.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions' -s h -l help -x -k -f -d 'Show this help.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions' -k -f -a bash -d 'Generate shell completions for bash.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions_bash' -s h -l help -x -k -f -d 'Show this help.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions_bash' -s n -l name -k -f -r -a '(completions-test completions complete string completions bash 2>/dev/null)' -d 'The name of the main command.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions' -k -f -a fish -d 'Generate shell completions for fish.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions_fish' -s h -l help -x -k -f -d 'Show this help.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions_fish' -s n -l name -k -f -r -a '(completions-test completions complete string completions fish 2>/dev/null)' -d 'The name of the main command.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions' -k -f -a zsh -d 'Generate shell completions for zsh.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions_zsh' -s h -l help -x -k -f -d 'Show this help.'
+complete -c completions-test -n '__fish_completions_test_using_command __completions_test_completions_zsh' -s n -l name -k -f -r -a '(completions-test completions complete string completions zsh 2>/dev/null)' -d 'The name of the main command.'
+\`
+stderr:
+""
+`;
+
 snapshot[`should generate file type completions in arguments > zsh 1`] = `
 stdout:
 \`#compdef completions-test

--- a/command/test/command/completion_test.ts
+++ b/command/test/command/completion_test.ts
@@ -145,6 +145,24 @@ await snapshotTest({
 });
 
 await snapshotTest({
+  name: "should escape backslashes in option descriptions for fish completions",
+  meta: import.meta,
+  steps: {
+    fish: { args: ["completions", "fish"] },
+  },
+  async fn(): Promise<void> {
+    await new Command()
+      .version("1.0.0")
+      .name("completions-test")
+      .option("--double-backslash <val:string>", "write a \\\\ for a backslash")
+      .option("--trailing-backslash <val:string>", "ends with a backslash\\")
+      .option("--single-quote <val:string>", "description with 'single quotes'")
+      .command("completions", new CompletionsCommand())
+      .parse();
+  },
+});
+
+await snapshotTest({
   name: "should generate file type completions in arguments",
   meta: import.meta,
   steps: {


### PR DESCRIPTION
The fish completions generator escapes single quotes in each option and command description, but leaves backslashes untouched:

```ts
const description: string = getDescription(options.description, true)
  // escape single quotes
  .replace(/'/g, "\'");

cmd.push("-d", `'${description}'`);
```

The description is emitted inside a single-quoted `-d '...'` argument. In fish, single quotes are not fully literal: a backslash inside them still escapes a following backslash or single quote (see [Quotes](https://fishshell.com/docs/current/language.html#quotes) in the fish docs). So a backslash in a description is mishandled:

- a doubled backslash collapses to a single one, and
- a trailing backslash escapes the closing quote, which ends the string early and breaks the generated completion script.

The zsh generator already escapes backslashes in descriptions for the same kind of reason (#872); fish was left out. This applies the same escape to fish, before the existing single-quote escape:

```ts
.replace(/\/g, "\\\\")
.replace(/'/g, "\'");
```

Added a snapshot test with a doubled backslash, a trailing backslash, and a single-quote case (so the existing quote escaping is shown to still work). Descriptions without backslashes are unaffected, so the existing snapshots don't change.
