### PR TITLE
fix(flags): match expected arguments when parsing stops early

### DIFF
--- a/command/command.ts
+++ b/command/command.ts
@@ -1394,8 +1394,9 @@ export class Command<
 
   /**
    * Enable stop early. If enabled, all arguments starting from the first non
-   * option argument will be passed as arguments with type string to the command
-   * action handler.
+   * option argument are passed as arguments to the command action handler.
+   * Arguments that match a declared argument are parsed with its type; use a
+   * variadic argument to collect the remaining arguments as strings.
    *
    * For example:
    *     `command --debug-level warning server --port 80`

--- a/command/test/command/stop_early_test.ts
+++ b/command/test/command/stop_early_test.ts
@@ -57,6 +57,66 @@ test("command stopEarly enabled", async () => {
   assertEquals(literal, ["--literal-arg1", "--literal-arg2"]);
 });
 
+test("command stopEarly with required argument", async () => {
+  const { options, args, literal } = await new Command()
+    .throwErrors()
+    .stopEarly()
+    .option("-f, --flag [value:boolean]", "description ...")
+    .option("-s, --script-arg1 [value:boolean]", "description ...")
+    .arguments("<script:string> [args...:string]")
+    .action(() => {})
+    .parse([
+      "-f",
+      "true",
+      "run",
+      "script-name",
+      "--script-arg1",
+      "--script-arg2",
+      "--",
+      "--literal-arg1",
+    ]);
+
+  assertEquals(options, { flag: true });
+  assertEquals(
+    args,
+    ["run", "script-name", "--script-arg1", "--script-arg2"],
+  );
+  assertEquals(literal, ["--literal-arg1"]);
+});
+
+test("command stopEarly missing required argument", async () => {
+  const cmd = new Command()
+    .throwErrors()
+    .stopEarly()
+    .option("-f, --flag [value:boolean]", "description ...")
+    .arguments("<script:string> [args...:string]")
+    .action(() => {});
+
+  await assertRejects(
+    async () => {
+      await cmd.parse(["-f", "true"]);
+    },
+    Error,
+    "Missing argument(s): script",
+  );
+});
+
+test("command stopEarly too many arguments", async () => {
+  const cmd = new Command()
+    .throwErrors()
+    .stopEarly()
+    .arguments("<script:string>")
+    .action(() => {});
+
+  await assertRejects(
+    async () => {
+      await cmd.parse(["run", "script-name"]);
+    },
+    Error,
+    "Too many arguments: script-name",
+  );
+});
+
 test("command stopEarly unknown option", async () => {
   const cmd = new Command()
     .throwErrors()

--- a/command/test/command/stop_early_test.ts
+++ b/command/test/command/stop_early_test.ts
@@ -117,6 +117,33 @@ test("command stopEarly too many arguments", async () => {
   );
 });
 
+test("command stopEarly parses typed argument", async () => {
+  const { args } = await new Command()
+    .throwErrors()
+    .stopEarly()
+    .arguments("<port:number> [args...:string]")
+    .action(() => {})
+    .parse(["8080", "--verbose", "extra"]);
+
+  assertEquals(args, [8080, "--verbose", "extra"]);
+});
+
+test("command stopEarly throws for an invalid typed argument", async () => {
+  const cmd = new Command()
+    .throwErrors()
+    .stopEarly()
+    .arguments("<port:number> [args...:string]")
+    .action(() => {});
+
+  await assertRejects(
+    async () => {
+      await cmd.parse(["not-a-number", "--verbose"]);
+    },
+    Error,
+    'Argument "port" must be of type "number", but got "not-a-number".',
+  );
+});
+
 test("command stopEarly unknown option", async () => {
   const cmd = new Command()
     .throwErrors()

--- a/flags/flags.ts
+++ b/flags/flags.ts
@@ -810,6 +810,20 @@ function validateArguments<TOptions extends FlagOptions = FlagOptions>(
   if (!opts.args?.length) {
     return;
   }
+
+  // When parsing stops early, every argument starting from the first non
+  // option argument is collected as an unknown argument, so that none of them
+  // are parsed as options. They are still the expected positional arguments,
+  // so they are moved over before they are validated. Arguments that exceed
+  // the expected arguments stay where they are and are reported as too many
+  // arguments below.
+  if (ctx.stopEarly || ctx.stopOnUnknown) {
+    const isVariadic = opts.args.some((expectedArg) => expectedArg.variadic);
+    const count = isVariadic ? ctx.unknown.length : opts.args.length;
+    ctx.args = ctx.unknown.slice(0, count);
+    ctx.unknown = ctx.unknown.slice(count);
+  }
+
   const hasDefaults = opts.args.some((arg) => arg.default !== undefined);
 
   if (!ctx.args?.length && !hasDefaults) {

--- a/flags/flags.ts
+++ b/flags/flags.ts
@@ -282,7 +282,9 @@ function parseArgs<TFlagOptions extends FlagOptions>(
       inLiteral = true;
       continue;
     } else if (ctx.stopEarly || ctx.stopOnUnknown) {
-      ctx.unknown.push(current);
+      if (!consumeArgument(current)) {
+        ctx.unknown.push(current);
+      }
       continue;
     }
 
@@ -291,8 +293,12 @@ function parseArgs<TFlagOptions extends FlagOptions>(
     if (!maybeIsFlag) {
       if (opts.stopEarly) {
         ctx.stopEarly = true;
+        if (!consumeArgument(current)) {
+          ctx.unknown.push(current);
+        }
+        continue;
       }
-      if (opts.stopEarly || !opts.args?.length) {
+      if (!opts.args?.length) {
         ctx.unknown.push(current);
         continue;
       }
@@ -333,7 +339,9 @@ function parseArgs<TFlagOptions extends FlagOptions>(
         if (!option) {
           if (opts.stopOnUnknown) {
             ctx.stopOnUnknown = true;
-            ctx.unknown.push(args[argsIndex]);
+            if (!consumeArgument(currentRaw)) {
+              ctx.unknown.push(currentRaw);
+            }
             continue;
           }
 
@@ -810,20 +818,6 @@ function validateArguments<TOptions extends FlagOptions = FlagOptions>(
   if (!opts.args?.length) {
     return;
   }
-
-  // When parsing stops early, every argument starting from the first non
-  // option argument is collected as an unknown argument, so that none of them
-  // are parsed as options. They are still the expected positional arguments,
-  // so they are moved over before they are validated. Arguments that exceed
-  // the expected arguments stay where they are and are reported as too many
-  // arguments below.
-  if (ctx.stopEarly || ctx.stopOnUnknown) {
-    const isVariadic = opts.args.some((expectedArg) => expectedArg.variadic);
-    const count = isVariadic ? ctx.unknown.length : opts.args.length;
-    ctx.args = ctx.unknown.slice(0, count);
-    ctx.unknown = ctx.unknown.slice(count);
-  }
-
   const hasDefaults = opts.args.some((arg) => arg.default !== undefined);
 
   if (!ctx.args?.length && !hasDefaults) {

--- a/flags/test/setting/stop_early_test.ts
+++ b/flags/test/setting/stop_early_test.ts
@@ -149,6 +149,75 @@ test("flags stopEarly too many arguments", () => {
   );
 });
 
+test("flags stopEarly parses expected arguments with their type", () => {
+  const { args, unknown } = parseFlags(["8080", "--port", "80"], {
+    stopEarly: true,
+    flags: [],
+    args: [{
+      name: "port",
+      type: "number",
+    }, {
+      name: "args",
+      type: "string",
+      variadic: true,
+      optional: true,
+    }],
+  });
+
+  assertEquals(args, [8080, "--port", "80"]);
+  assertEquals(unknown, []);
+});
+
+test("flags stopEarly throws for an invalid argument type", () => {
+  assertThrows(
+    () =>
+      parseFlags(["not-a-number", "--port", "80"], {
+        stopEarly: true,
+        flags: [],
+        args: [{
+          name: "port",
+          type: "number",
+        }, {
+          name: "args",
+          type: "string",
+          variadic: true,
+          optional: true,
+        }],
+      }),
+    Error,
+    'Argument "port" must be of type "number", but got "not-a-number".',
+  );
+});
+
+test("flags stopOnUnknown parses expected arguments with their type", () => {
+  const { flags, args, unknown } = parseFlags([
+    "--known",
+    "value",
+    "8080",
+    "--unknown",
+    "arg",
+  ], {
+    stopOnUnknown: true,
+    flags: [{
+      name: "known",
+      type: "string",
+    }],
+    args: [{
+      name: "port",
+      type: "number",
+    }, {
+      name: "args",
+      type: "string",
+      variadic: true,
+      optional: true,
+    }],
+  });
+
+  assertEquals(flags, { known: "value" });
+  assertEquals(args, [8080, "--unknown", "arg"]);
+  assertEquals(unknown, []);
+});
+
 test("flags stopEarly unknown option", () => {
   assertThrows(
     () =>

--- a/flags/test/setting/stop_early_test.ts
+++ b/flags/test/setting/stop_early_test.ts
@@ -78,6 +78,77 @@ test("flags stopEarly enabled", () => {
   assertEquals(literal, ["--literal-arg1", "--literal-arg2"]);
 });
 
+test("flags stopEarly with expected arguments", () => {
+  const { flags, args, unknown, literal } = parseFlags([
+    "-f",
+    "true",
+    "run",
+    "script-name",
+    "--script-arg1",
+    "--",
+    "--literal-arg1",
+  ], {
+    stopEarly: true,
+    flags: [{
+      name: "flag",
+      aliases: ["f"],
+      type: "boolean",
+      optionalValue: true,
+    }],
+    args: [{
+      name: "script",
+      type: "string",
+    }, {
+      name: "args",
+      type: "string",
+      variadic: true,
+      optional: true,
+    }],
+  });
+
+  assertEquals(flags, { flag: true });
+  assertEquals(args, ["run", "script-name", "--script-arg1"]);
+  assertEquals(unknown, []);
+  assertEquals(literal, ["--literal-arg1"]);
+});
+
+test("flags stopEarly missing required argument", () => {
+  assertThrows(
+    () =>
+      parseFlags(["-f", "true"], {
+        stopEarly: true,
+        flags: [{
+          name: "flag",
+          aliases: ["f"],
+          type: "boolean",
+          optionalValue: true,
+        }],
+        args: [{
+          name: "script",
+          type: "string",
+        }],
+      }),
+    Error,
+    "Missing argument(s): script",
+  );
+});
+
+test("flags stopEarly too many arguments", () => {
+  assertThrows(
+    () =>
+      parseFlags(["run", "script-name"], {
+        stopEarly: true,
+        flags: [],
+        args: [{
+          name: "script",
+          type: "string",
+        }],
+      }),
+    Error,
+    "Too many arguments: script-name",
+  );
+});
+
 test("flags stopEarly unknown option", () => {
   assertThrows(
     () =>

--- a/flags/types.ts
+++ b/flags/types.ts
@@ -10,8 +10,11 @@ export interface ParseFlagsOptions<
   /** Option callback function. Will be called for all parsed options. */
   option?: (option: TFlagOptions, value?: unknown) => void;
   /**
-   * Enable stop early. If enabled, all arguments starting from the first non
-   * option argument will be added to the unknown array.
+   * If enabled, all arguments starting from the first none option argument are
+   * no longer parsed as options. Arguments matching an expected argument from
+   * the `args` option are parsed with their type and added to the `args` array,
+   * any remaining arguments are added to the unknown array. Without expected
+   * arguments, all of them are added to the unknown array.
    *
    * For example:
    *     `command --debug-level warning server --port 80`
@@ -21,7 +24,7 @@ export interface ParseFlagsOptions<
    *     - unknown: `['server', '--port', '80']`
    */
   stopEarly?: boolean;
-  /** Works similar to `stopEarly`, bit stops on first unknown option or argument. */
+  /** Works similar to `stopEarly`, but stops on the first unknown option or argument. */
   stopOnUnknown?: boolean;
   /**
    * Don't throw an error when no arguments are passed to the `parseFlags`


### PR DESCRIPTION
When stop early is enabled, every argument from the first non option argument onwards is collected as an unknown argument, so that none of them are parsed as options. Since the flags parser learned about positional arguments, the argument validator reads them from `ctx.args`, which stays empty in that case, so every expected argument that is not optional is reported as missing and parsing fails before the command runs:

    new Command()
      .stopEarly()
      .arguments("<script:string> [args...:string]")
      .parse(["run", "--script-arg"]);
    // error: Missing argument(s): script

This contradicts what stop early documents, which is that those arguments are passed to the action handler. `Command.processArguments` does assign them from the unknown arguments, but it runs after the validator has already thrown, so it is never reached.

Move the arguments over before they are validated, so that the existing matching applies to them. Arguments that exceed the expected arguments are left where they are and are still reported as too many arguments.

The existing tests for this setting declare only optional arguments, so the required case was not covered. Add tests for it at both layers.