### PR TITLE
fix(flags): report every surplus argument as too many arguments

### DIFF
--- a/flags/flags.ts
+++ b/flags/flags.ts
@@ -391,7 +391,11 @@ function parseArgs<TFlagOptions extends FlagOptions>(
           }
 
           if (!maybeIsFlag) {
-            throw new TooManyArgumentsError([currentRaw]);
+            // Collect the argument instead of throwing here, so that every
+            // surplus argument is reported and not only the first one. The
+            // error is thrown by `validateArguments` once parsing is done.
+            ctx.unknown.push(currentRaw);
+            continue;
           }
           throw new UnknownOptionError(current, opts.flags);
         }

--- a/flags/test/flags/arguments_test.ts
+++ b/flags/test/flags/arguments_test.ts
@@ -128,6 +128,32 @@ test("should throw TooManyArgumentsError for extra positional args", () => {
   );
 });
 
+test("should list all extra positional args in TooManyArgumentsError", () => {
+  assertThrows(
+    () => {
+      parseFlags(["foo", "bar", "baz", "beep"], {
+        flags: [{ name: "recursive", aliases: ["r"], type: "string" }],
+        args: [{ type: "string", name: "dir" }],
+      });
+    },
+    Error,
+    "Too many arguments: bar baz beep",
+  );
+});
+
+test("should not list option values as extra positional args", () => {
+  assertThrows(
+    () => {
+      parseFlags(["foo", "bar", "--recursive", "baz"], {
+        flags: [{ name: "recursive", aliases: ["r"], type: "string" }],
+        args: [{ type: "string", name: "dir" }],
+      });
+    },
+    Error,
+    "Too many arguments: bar",
+  );
+});
+
 test("should suppress missing args error when standalone option is present", () => {
   const { flags, args } = parseFlags(["--help"], {
     flags: [{ name: "help", standalone: true }],

--- a/flags/test/flags/arguments_test.ts
+++ b/flags/test/flags/arguments_test.ts
@@ -154,6 +154,24 @@ test("should not list option values as extra positional args", () => {
   );
 });
 
+test("should report a missing required option before too many arguments", () => {
+  assertThrows(
+    () => {
+      parseFlags(["foo", "bar"], {
+        flags: [{
+          name: "recursive",
+          aliases: ["r"],
+          type: "string",
+          required: true,
+        }],
+        args: [{ type: "string", name: "dir" }],
+      });
+    },
+    Error,
+    'Missing required option "--recursive".',
+  );
+});
+
 test("should suppress missing args error when standalone option is present", () => {
   const { flags, args } = parseFlags(["--help"], {
     flags: [{ name: "help", standalone: true }],


### PR DESCRIPTION
An argument that matches none of the expected arguments throws right away, with only the argument in hand, so a single argument is reported however many were passed:

    parseFlags(["a", "b", "c", "d"], {
      flags: [{ name: "recursive", type: "string" }],
      args: [{ name: "dir", type: "string" }],
    });
    // error: Too many arguments: b

Collect the argument as an unknown argument instead and let the validator throw once parsing has finished, which reports all of them: "Too many arguments: b c d".

Parsing therefore continues past the first surplus argument, which is what keeps option values out of the error: in `["a", "b", "--recursive", "baz"]`, "baz" is read as the value of `--recursive` and only "b" is reported.

The existing test passes a single surplus argument, so it holds either way. Add tests for several surplus arguments and for an option value following them.